### PR TITLE
Update lib.js

### DIFF
--- a/js/lib.js
+++ b/js/lib.js
@@ -312,8 +312,9 @@ function AJAX_getXMLHttpObject()
 function AJAX_sendPOSTHeaders(http, contentLength)
 {
     http.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-    http.setRequestHeader('Content-length', contentLength);
-    http.setRequestHeader('Connection', 'close');
+    /* No more allowed! */
+    //http.setRequestHeader('Content-length', contentLength);
+    //http.setRequestHeader('Connection', 'close');
 }
 
 /**


### PR DESCRIPTION
I commented some lines in the AJAX_sendPOSTHeaders function (line 312)
'Content-length' and 'Connection' headers are now considered unsafe by browsers when used with setRequestHeader
See https://www.w3.org/TR/XMLHttpRequest/#dom-xmlhttprequest-setrequestheader