### PR TITLE
Added grave accents, backticks, to database schema name

### DIFF
--- a/modules/install/ajax/ui.php
+++ b/modules/install/ajax/ui.php
@@ -754,7 +754,7 @@ switch ($action)
 
         //Check if we need to update from 0.6.0 to 0.7.0
         $tables = array();
-        $result = MySQLQuery(sprintf("SHOW TABLES FROM %s", DATABASE_NAME));
+        $result = MySQLQuery(sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME));
         while ($row = mysql_fetch_array($result, MYSQL_NUM))
         {
             $tables[$row[0]] = true;

--- a/modules/install/ajax/ui.php
+++ b/modules/install/ajax/ui.php
@@ -1064,7 +1064,7 @@ function MySQLConnect()
 
     /* Create an array of all tables in the database. */
     $tables = array();
-    $result = MySQLQuery(sprintf("SHOW TABLES FROM %s", DATABASE_NAME));
+    $result = MySQLQuery(sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME));
     while ($row = mysql_fetch_row($result))
     {
         $tables[$row[0]] = true;

--- a/modules/install/backupDB.php
+++ b/modules/install/backupDB.php
@@ -80,7 +80,7 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
     $text = '';
 
     $result = mysql_query(
-        sprintf("SHOW TABLES FROM %s", DATABASE_NAME),
+        sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME),
         $connection
     );
     while ($row = mysql_fetch_array($result, MYSQL_NUM))


### PR DESCRIPTION
When an existing database schema uses a reserved name, like numbers only, backticks prevent errors.