### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM php:5.5-apache
+
+RUN apt-get update && \
+    apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libncurses5-dev \
+        libicu-dev \
+        libmemcached-dev \
+        libcurl4-openssl-dev \
+		libpng-dev \
+        libpng12-dev \
+        libgmp-dev \
+        libxml2-dev \
+		libldap2-dev \
+		php-soap \
+        curl \
+        zlib1g-dev \
+        ssmtp
+
+RUN apt-get install -y \
+		antiword \
+		poppler-utils \
+		html2text \
+		unrtf
+
+RUN rm -rf /var/lib/apt/lists/* 
+	
+RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
+
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
+    docker-php-ext-configure mysql --with-mysql=mysqlnd && \
+    docker-php-ext-configure mysqli --with-mysqli=mysqlnd && \
+    docker-php-ext-install mysqli && \
+    docker-php-ext-install mysql && \
+    docker-php-ext-install ldap && \
+    docker-php-ext-install soap && \
+    docker-php-ext-install intl && \
+    docker-php-ext-install mcrypt && \
+    docker-php-ext-install gd && \
+    docker-php-ext-install gmp && \
+    docker-php-ext-install zip
+
+COPY . /var/www/html
+
+WORKDIR /var/www/html
+
+EXPOSE 80
+EXPOSE 443


### PR DESCRIPTION
Added support to Dockerize OpenCATS.

This is basic not optimized docker file to build image without database. It is based on php5.5-apache.

Known issues:
* when built docker image on windows from cloned repository, files using CR+LF as EOL. It causes problem when creating DB schema using file `db/cats_schema.sql`. It is necessary to have LF EOL (Linux like).
* config.php is not modified so in some cases manual modification after installation is necessary.
* all files are added into image, some of them shall not be provided, optimization needed.

Example of `docker-compose.yml` using mysqldb and phpmyadmin in extra containers.
```yml
opencats:
    container_name: opencats
    build: .
    ports:
        - 80:80
        - 443:80
    links:
        - mysql

mysql:
    container_name: mysqlserver
    image: mysql:5.5
    ports:
        - 3306:3306
    volumes:
        - /var/lib/mysql
    environment:
        MYSQL_ROOT_PASSWORD: root
        MYSQL_DATABASE: cats_dev
        MYSQL_USER: cats
        MYSQL_PASSWORD: password

phpmyadmin:
    container_name: phpmyadmin
    image: phpmyadmin/phpmyadmin
    ports:
        - 8080:80
    links:
        - mysql:db
    environment:
        PMA_HOST: db
        PMA_USER: cats
        PMA_PASSWORD: password
```