### PR TITLE
Mysql utf8 character set

### DIFF
--- a/config.php
+++ b/config.php
@@ -126,6 +126,9 @@ define('HTML_ENCODING', 'UTF-8');
 /* AJAX Encoding. */
 define('AJAX_ENCODING', 'UTF-8');
 
+/* SQL Character Set. */
+define('SQL_CHARACTER_SET', 'utf8');
+
 /* Insert BOM in the beginning of CSV file */
 /* This is UTF-8 BOM, EF BB BF for UTF-8 */
 define('INSERT_BOM_CSV_LENGTH', '3');

--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -1009,7 +1009,7 @@ CREATE TABLE `sph_counter` (
   `counter_id` int(11) NOT NULL,
   `max_doc_id` int(11) NOT NULL,
   PRIMARY KEY (`counter_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 /*Data for the table `sph_counter` */
 

--- a/db/upgrade-0.5.2-0.5.5.sql
+++ b/db/upgrade-0.5.2-0.5.5.sql
@@ -122,8 +122,8 @@ CREATE TABLE `mru` (
   `user_id` int(11) NOT NULL default '0',
   `site_id` int(11) NOT NULL default '0',
   `data_item_type` int(11) NOT NULL default '0',
-  `data_item_text` varchar(64) character set latin1 NOT NULL default '',
-  `url` varchar(255) character set latin1 NOT NULL default '',
+  `data_item_text` varchar(64) character set utf8 NOT NULL default '',
+  `url` varchar(255) character set utf8 NOT NULL default '',
   `date_created` datetime NOT NULL default '0000-00-00 00:00:00',
   PRIMARY KEY  (`mru_id`),
   KEY `IDX_user_site` (`user_id`,`site_id`)

--- a/db/upgrade-0.5.5-0.6.x.sql
+++ b/db/upgrade-0.5.5-0.6.x.sql
@@ -10,7 +10,7 @@ CREATE TABLE `candidate_foreign` (
   `import_id` int(11) default NULL,
   PRIMARY KEY  (`alien_id`),
   KEY `assoc_id` (`assoc_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `client_foreign` (
   `alien_id` int(11) NOT NULL auto_increment,
@@ -20,7 +20,7 @@ CREATE TABLE `client_foreign` (
   `import_id` int(11) default NULL,
   PRIMARY KEY  (`alien_id`),
   KEY `assoc_id` (`assoc_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `contact_foreign` (
   `alien_id` int(11) NOT NULL auto_increment,
@@ -30,7 +30,7 @@ CREATE TABLE `contact_foreign` (
   `import_id` int(11) default NULL,
   PRIMARY KEY  (`alien_id`),
   KEY `assoc_id` (`assoc_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `import` (
   `import_id` int(11) NOT NULL auto_increment,
@@ -40,7 +40,7 @@ CREATE TABLE `import` (
   `import_errors` longtext,
   `added_lines` int(11) default NULL,
   PRIMARY KEY  (`import_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `candidate` ADD COLUMN `import_id` INTEGER(11) NOT NULL DEFAULT '0';
 ALTER TABLE `contact` ADD COLUMN `import_id` INTEGER(11) NOT NULL DEFAULT '0';
@@ -94,7 +94,7 @@ CREATE TABLE `saved_search` (
   `site_id` int(11) default NULL,
   `date_created` datetime default NULL,
   PRIMARY KEY  (`search_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 #r518 8-11-6 PC
 UPDATE system SET schema_version = 518;
@@ -104,7 +104,7 @@ CREATE TABLE `hot_list` (
   `hot_list_type` int(11) NOT NULL default 0,
   `site_id` int(11) NOT NULL default 0,
   PRIMARY KEY (`hot_list_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 ALTER TABLE `candidate` ADD COLUMN `is_hot` INT(1) NOT NULL DEFAULT 0;
 ALTER TABLE `candidate` ADD COLUMN `hot_list_id` int(11) NULL;
 
@@ -187,7 +187,7 @@ CREATE TABLE `candidate_source` (
   `date_created` datetime default NULL,
   PRIMARY KEY  (`source_id`),
   KEY `siteID` (`site_id`)
-) ENGINE=MYISAM DEFAULT CHARSET=latin1;
+) ENGINE=MYISAM DEFAULT CHARSET=utf8;
 
 #r538 8-11-6 WB
 UPDATE system SET schema_version = 538;

--- a/lib/DatabaseConnection.php
+++ b/lib/DatabaseConnection.php
@@ -123,7 +123,7 @@ class DatabaseConnection
             );
             return false;
         }
-
+        mysql_set_charset(SQL_CHARACTER_SET, $this->_connection);
         $isDBSelected = @mysql_select_db(DATABASE_NAME, $this->_connection);
         if (!$isDBSelected)
         {

--- a/modules/settings/CareerPortalSettings.tpl
+++ b/modules/settings/CareerPortalSettings.tpl
@@ -244,7 +244,7 @@
                                     <span id="textTemplateName" style="font-weight: bold; font-size: 18px;"></span>
                                     <br />
                                     <input type="button" class="button" value="Full Screen Preview" onclick="fullScreenPreview();" />
-                                    <input type="button" class="button" value="Edit" id="buttonEdit" onclick="window.location.href='<?php echo(CATSUtility::getIndexName()); ?>?m=settings&amp;a=careerPortalTemplateEdit&amp;templateName='+escape(usingID);" />
+                                    <input type="button" class="button" value="Edit" id="buttonEdit" onclick="window.location.href='<?php echo(CATSUtility::getIndexName()); ?>?m=settings&amp;a=careerPortalTemplateEdit&amp;templateName='+encodeURI(usingID);" />
                                     <input type="button" class="button" value="Edit" id="buttonEditDefault" onclick="showEditDefaultInput();" style="display: none;" />
                                     <input type="button" class="button" value="Delete" id="buttonDelete" onclick="showDeleteInput();" />
                                     <input type="button" class="button" value="Duplicate" onclick="showDuplicateInput();" />

--- a/modules/settings/CustomizeExtraFields.tpl
+++ b/modules/settings/CustomizeExtraFields.tpl
@@ -30,7 +30,7 @@
                 <script type="text/javascript">
                    function appendCommandList(command)
                    {
-                      document.getElementById('commandList').value = document.getElementById('commandList').value + escape(command) + ',';
+                      document.getElementById('commandList').value = document.getElementById('commandList').value + encodeURI(command) + ',';
                       document.getElementById('changedDiv').style.display = '';
                       document.getElementById('buttonSave').style.display = '';
                       document.getElementById('buttonDone').style.display = 'none';
@@ -292,7 +292,7 @@
                                             addOptionsAreaToTable<?php echo($index); ?>(thisIndex, rowName);
                                         }
                                         
-                                        appendCommandList('ADDFIELD <?php echo(urlencode($data['type'])); ?> '+escape(rowType)+' '+escape(rowName));
+                                        appendCommandList('ADDFIELD <?php echo(urlencode($data['type'])); ?> '+encodeURI(rowType)+' '+encodeURI(rowName));
                                     }
                                     
                                     //TODO: Document me.
@@ -309,7 +309,7 @@
                                         
                                         deleteRowFromTable<?php echo($index); ?>(rowIndex);
                                         
-                                        appendCommandList('DELETEFIELD <?php echo(urlencode($data['type'])); ?> '+escape(rowName));
+                                        appendCommandList('DELETEFIELD <?php echo(urlencode($data['type'])); ?> '+encodeURI(rowName));
                                     }
 
                                     //TODO: Document me.
@@ -354,7 +354,7 @@
                                         col.innerHTML = html2;
                                         col2.innerHTML = html;    
                                         
-                                        appendCommandList('SWAPFIELDS <?php echo(urlencode($data['type'])); ?> '+escape(rowName1)+':'+escape(rowName2));
+                                        appendCommandList('SWAPFIELDS <?php echo(urlencode($data['type'])); ?> '+encodeURI(rowName1)+':'+encodeURI(rowName2));
                                     }
 
                                     //TODO: Document me.
@@ -384,7 +384,7 @@
                                           var rowNameOrg = document.getElementById('inlineEditOrg'+inlineID).value;
                                           var rowNameNew = document.getElementById('inlineEdit'+inlineID).value;
                                           
-                                          appendCommandList('RENAMEROW <?php echo(urlencode($data['type'])); ?> '+escape(rowNameOrg)+':'+escape(rowNameNew));
+                                          appendCommandList('RENAMEROW <?php echo(urlencode($data['type'])); ?> '+encodeURI(rowNameOrg)+':'+encodeURI(rowNameNew));
 
                                           document.getElementById('editSettingsForm').submit();
                                       }                                    
@@ -417,7 +417,7 @@
                                         
                                         addOptionToTable<?php echo($index); ?>(optionName, tbl, fieldName);
                                         
-                                        appendCommandList('ADDOPTION <?php echo(urlencode($data['type'])); ?> '+escape(fieldName)+':'+escape(optionName));
+                                        appendCommandList('ADDOPTION <?php echo(urlencode($data['type'])); ?> '+encodeURI(fieldName)+':'+encodeURI(optionName));
                                     }
                                     
                                     //TODO: Document me.
@@ -433,7 +433,7 @@
                                         
                                         deleteOptionFromTable<?php echo($index); ?>(rowOptions, optionName, fieldName);
                                         
-                                        appendCommandList('DELETEOPTION <?php echo(urlencode($data['type'])); ?> '+escape(fieldName)+':'+escape(optionName));
+                                        appendCommandList('DELETEOPTION <?php echo(urlencode($data['type'])); ?> '+encodeURI(fieldName)+':'+encodeURI(optionName));
                                     }                                    
                                     
                                     //TODO: Document me.


### PR DESCRIPTION
This change add supports for utf8 databases by default and fixes a bug with extra fields functionality. 

I've added a new configuration file that allows support for old databases in latin1 without doing any migration, we only need to change the following line:

`define('SQL_CHARACTER_SET', 'utf8');`

with 

`define('SQL_CHARACTER_SET', 'latin1');`

There might be other places in the application where utf8 code is not 100% supported (i've seen there is an issue with Calendar) but did not have the time to test the whole app yet.

So far we're using this in production with companies, candidates, contacts and using extra field functionality with no issues. 
 