### PR TITLE
Fix of permission in contacts for readOnly user

### DIFF
--- a/modules/contacts/Contacts.tpl
+++ b/modules/contacts/Contacts.tpl
@@ -90,6 +90,7 @@
                 &nbsp;
             </div>
             <br /><br />
+                <?php if ($this->accessLevel >= ACCESS_LEVEL_EDIT): ?>
             <table cellpadding="0" cellspacing="0" border="0" width="956">
                 <tr>
                 <td style="padding-left: 62px;" align="center" valign="center">
@@ -105,6 +106,7 @@
 
                 </tr>
             </table>
+                <?php endif; ?>
 
             <?php endif; ?>
 

--- a/modules/contacts/ContactsUI.php
+++ b/modules/contacts/ContactsUI.php
@@ -383,6 +383,12 @@ class ContactsUI extends UserInterface
      */
     private function add()
     {
+        /* Bail if we don't have add permision. */
+        if ($this->_accessLevel < ACCESS_LEVEL_EDIT)
+        {
+            CommonErrors::fatal(COMMONERROR_PERMISSION, $this, 'Invalid user level for action.');
+        }
+
         $companies = new Companies($this->_siteID);
         $contacts = new Contacts($this->_siteID);
 


### PR DESCRIPTION
Added checks of access level in display of addContacts in Contacts page and also 'add' action call.

resolves #101