### PR TITLE
Fix of permission in candidates for readOnly user

### DIFF
--- a/modules/candidates/Candidates.tpl
+++ b/modules/candidates/Candidates.tpl
@@ -137,6 +137,7 @@
                 &nbsp;
             </div>
             <br /><br />
+                <?php if ($this->accessLevel >= ACCESS_LEVEL_EDIT): ?>
             <table cellpadding="0" cellspacing="0" border="0" width="956">
                 <tr>
                 <td style="padding-left: 62px;" align="center" valign="center">
@@ -163,6 +164,7 @@
 
                 </tr>
             </table>
+                <?php endif; ?>
 
             <?php endif; ?>
         </div>

--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -623,6 +623,12 @@ class CandidatesUI extends UserInterface
      */
     private function add($contents = '', $fields = array())
     {
+
+        if ($this->_accessLevel < ACCESS_LEVEL_EDIT)
+        {
+            CommonErrors::fatal(COMMONERROR_PERMISSION, $this, 'Invalid user level for action.');
+        }
+
         $candidates = new Candidates($this->_siteID);
 
         /* Get possible sources. */


### PR DESCRIPTION
Added checks of access level in display of addCandidates in Candidates page and also 'add' action call.

resolves #107