### PR TITLE
Fix of permission in Job Orders for readOnly user

### DIFF
--- a/modules/joborders/JobOrders.tpl
+++ b/modules/joborders/JobOrders.tpl
@@ -104,6 +104,7 @@
                 &nbsp;
             </div>
             <br /><br />
+                 <?php if ($this->accessLevel >= ACCESS_LEVEL_EDIT): ?>
             <table cellpadding="0" cellspacing="0" border="0">
                 <tr>
                 <td style="padding-left: 62px;" align="center" valign="center">
@@ -120,6 +121,7 @@
 
                 </tr>
             </table>
+                <?php endif; ?>
 
             <?php endif; ?>
         </div>

--- a/modules/joborders/JobOrdersUI.php
+++ b/modules/joborders/JobOrdersUI.php
@@ -483,6 +483,11 @@ class JobOrdersUI extends UserInterface
      */
     private function add()
     {
+        if ($this->_accessLevel < ACCESS_LEVEL_EDIT)
+        {
+            CommonErrors::fatal(COMMONERROR_PERMISSION, $this, 'Invalid user level for action.');
+        }
+
         $users = new Users($this->_siteID);
         $usersRS = $users->getSelectList();
 


### PR DESCRIPTION
Added checks of access level in display of addJobOrder in Job Orders page and also 'add' action call.

resolves #109 