### PR TITLE
Zipcode address completion via google

### DIFF
--- a/ajax/zipLookup.php
+++ b/ajax/zipLookup.php
@@ -1,30 +1,7 @@
 <?php
 /*
- * CATS
- * AJAX City/State lookup via Zip Interface
- *
- * Copyright (C) 2005 - 2007 Cognizo Technologies, Inc.
- *
- *
- * The contents of this file are subject to the CATS Public License
- * Version 1.1a (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://www.catsone.com/.
- *
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- *
- * The Original Code is "CATS Standard Edition".
- *
- * The Initial Developer of the Original Code is Cognizo Technologies, Inc.
- * Portions created by the Initial Developer are Copyright (C) 2005 - 2007
- * (or from the year in which this file was created to the year 2007) by
- * Cognizo Technologies, Inc. All Rights Reserved.
- *
- *
- * $Id: zipLookup.php 1479 2007-01-17 00:22:21Z will $
+ * OpenCATS
+ * AJAX Street/City/State lookup via Zip Interface
  */
 include_once('./lib/ZipLookup.php');
 include_once('./lib/StringUtility.php');
@@ -54,8 +31,9 @@ $interface->outputXMLPage(
     "<data>\n" .
     "    <errorcode>0</errorcode>\n" .
     "    <errormessage></errormessage>\n" .
-    "    <city>"   . $city  . "</city>\n" .
-    "    <state>"  . $state . "</state>\n" .
+    "    <address>" . $street. "</address>\n .
+    "    <city>"    . $city  . "</city>\n" .
+    "    <state>"   . $state . "</state>\n" .
     "</data>\n"
 );
 ?>

--- a/ajax/zipLookup.php
+++ b/ajax/zipLookup.php
@@ -26,7 +26,6 @@
  *
  * $Id: zipLookup.php 1479 2007-01-17 00:22:21Z will $
  */
-
 include_once('./lib/ZipLookup.php');
 include_once('./lib/StringUtility.php');
 
@@ -41,12 +40,14 @@ if (!isset($_REQUEST['zip']))
 $zip = $_REQUEST['zip'];
 
 $zipLookup = new ZipLookup();
+
 $searchableZip = $zipLookup->makeSearchableUSZip($zip);
 
 $data = $zipLookup->getCityStateByZip($searchableZip);
 
-$city  = $data['city'];
-$state = $data['state'];
+$street = $data[1];
+$city  = $data[2];
+$state = $data[3];
 
 /* Send back the XML data. */
 $interface->outputXMLPage(
@@ -57,5 +58,4 @@ $interface->outputXMLPage(
     "    <state>"  . $state . "</state>\n" .
     "</data>\n"
 );
-
 ?>

--- a/js/lib.js
+++ b/js/lib.js
@@ -553,8 +553,21 @@ function CityState_populate(zipEditID, indicatorID)
             return;
         }
 
+	var addressNode = http.responseXML.getElementsByTagName('address').item(0);
         var cityNode  = http.responseXML.getElementsByTagName('city').item(0);
         var stateNode = http.responseXML.getElementsByTagName('state').item(0);
+
+	if (document.getElementById('address'))
+        {
+            if (addressNode.firstChild)
+            {
+                document.getElementById('address').value = addressNode.firstChild.nodeValue;
+            }
+            else
+            {
+                document.getElementById('address').value = '';
+            }
+        }
 
         if (document.getElementById('city'))
         {
@@ -1071,11 +1084,8 @@ function rot13(theString)
 
 /*
 PROJECT: Javascript Based Base64 Encoding and Decoding Engine
-
 DATE: 02/10/2004
-
 AUTHOR: Adrian Bacon
-
 COPYRIGHT: You are free to use this code as you see fit provided
 that you send any changes or modifications back to me.
 */
@@ -1115,5 +1125,3 @@ function decode64(input)
 
    return output;
 }
-
-

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -1,94 +1,26 @@
 <?php
 /**
- * CATS
- * Zip Code Lookup Library
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- * @package    CATS
- * @subpackage Library
- *
- *
- */
-/**
- *	Zip Code Lookup Library
- *	@package    CATS
- *	@subpackage Library
- */
+* Google API Zip Code Lookup library
+* @package OpenCATS
+* @subpackage Library
+* @copyright (C) OpenCats
+* @license GNU/GPL, see license.txt
+* OpenCATS is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License 2
+* as published by the Free Software Foundation.
+*/
 class ZipLookup
 {
-    /**
-     * Makes a proper "searchable" United States Zip code from a given Zip
-     * code string. All whitespace and leading 0's are removed.
-     *
-     * @param string free-form Zip code (ex: 55121, 30504 - 1000, 01369-5463)
-     * @return integer 3-5 digit searchable zip code or 0 on failure
-     */
+
      public static function makeSearchableUSZip($zipString)
      {
-	/*
-        if (preg_match('/^\s*[0]*(\d{3,5})\s*(?:-.*)?$/', $zipString, $match))
-        {
-            return (int) $match[1];
-        }
-        return 0;
-	*/
+
 	return str_replace(' ', '', $zipString);
      }
-    /**
-     * Finds City and State names via United States Zip code. The Zip code
-     * should be specified as an integer with no leading 0s.
-     *
-     * @param integer United States Zip code
-     * @return array city / state data (empty strings if not found)
-     */
+
     public function getCityStateByZip($zip)
     {
-        /* Make sure we have an integer. */
 
-	/*
-        $zip = (int) $zip;
-        if ($zip === 0)
-        {
-            return array('city' => '', 'state' => '');
-        }
-        $db = DatabaseConnection::getInstance();
-        $sql = sprintf(
-            "SELECT
-                city AS city,
-                state AS state
-            FROM
-                zipcodes
-            WHERE
-                zipcode = %s",
-            $zip
-        );
-        $data = $db->getAssoc($sql);
-        if (empty($data))
-        {
-            return array('city' => '', 'state' => '');
-        }
-        return $data;
-	*/
 
 	$aAddress[0] = 0;
 	$aAddress[1] = '';
@@ -103,7 +35,10 @@ class ZipLookup
 				if ($value->type == 'route') {
 					$aAddress[1] = (string) $value->long_name;
 				}
-				if ($value->type == 'postal_town') {
+				if ($value->type[0] == 'locality') {
+					$aAddress[2] = (string) $value->long_name;
+				}
+				if (($value->type == 'postal_town') && ($aAddress[2] == '')) {
 					$aAddress[2] = (string) $value->long_name;
 				}
 				if ($value->type[0] == 'administrative_area_level_2') {

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -1,13 +1,6 @@
 <?php
 /**
 * Google API Zip Code Lookup library
-* @package OpenCATS
-* @subpackage Library
-* @copyright (C) OpenCats
-* @license GNU/GPL, see license.txt
-* OpenCATS is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public License 2
-* as published by the Free Software Foundation.
 */
 class ZipLookup
 {

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -3,31 +3,31 @@
  * CATS
  * Zip Code Lookup Library
  *
- * Copyright (C) 2005 - 2007 Cognizo Technologies, Inc.
  *
  *
- * The contents of this file are subject to the CATS Public License
- * Version 1.1a (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://www.catsone.com/.
  *
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
  *
- * The Original Code is "CATS Standard Edition".
  *
- * The Initial Developer of the Original Code is Cognizo Technologies, Inc.
- * Portions created by the Initial Developer are Copyright (C) 2005 - 2007
- * (or from the year in which this file was created to the year 2007) by
- * Cognizo Technologies, Inc. All Rights Reserved.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
  *
  *
  * @package    CATS
  * @subpackage Library
- * @copyright Copyright (C) 2005 - 2007 Cognizo Technologies, Inc.
- * @version    $Id: ZipLookup.php 3587 2007-11-13 03:55:57Z will $
+ *
+ *
  */
 /**
  *	Zip Code Lookup Library

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -31,7 +31,7 @@ class ZipLookup
 
 	if ($zip != '') {
 		if (($oXml = simplexml_load_file($sUrl . $zip))) {
-			foreach($oXml->result->address_component as $key => $value) {
+			foreach($oXml->result->address_component as $value) {
 				if ($value->type == 'route') {
 					$aAddress[1] = (string) $value->long_name;
 				}


### PR DESCRIPTION
This is a working update to allow candidate address completion by a zipcode lookup using a google api. The api allows free usage of 2,500 queries per day per IP address. Of course, google changes it's api's frequently - but if we use this we can remove the 'zipcode table' from the database.

This closes  #38 

I will have to add some comments into documentation as different countries may want to return different values from the lookup for City and State - see the comments on #38.

Coding entirely provided by Dale Stringfellow ( @thedss ), with testing / feedback  from me 