### PR TITLE
Used mysqli procedural methods instead of mysql methods.

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -20,7 +20,7 @@ RUN cd ~ && \
   ./configure && \
   make && \
   make install
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && docker-php-ext-install -j5 mysql gd ldap soap zip
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && docker-php-ext-install -j5 mysqli gd ldap soap zip
 ADD scripts/install-composer.sh /opt/install-composer.sh
 RUN dos2unix /opt/install-composer.sh && \
   chmod +x /opt/install-composer.sh && \

--- a/index.php
+++ b/index.php
@@ -124,9 +124,9 @@ if (ini_get('session.auto_start') !== '0' &&
 }
 
 /* Proper extensions loaded?! */
-if (!function_exists('mysql_connect') || !function_exists('session_start'))
+if (!function_exists('mysqli_connect') || !function_exists('session_start'))
 {
-    die('CATS Error: All required PHP extensions are not loaded.');
+    die('OpenCATS Error: Either PHP Sessions extension or MySQLi extension is not loaded.');
 }
 
 /* Make sure we have a Session object stored in the user's session. */

--- a/lib/CommonErrors.php
+++ b/lib/CommonErrors.php
@@ -295,7 +295,7 @@ class CommonErrors
         $db = DatabaseConnection::getInstance();
         $tables = array();
         $rs = $db->query('show tables');
-        while ($tbl = mysql_fetch_array($rs)) $tables[] = $tbl[0];
+        while ($tbl = mysqli_fetch_array($rs)) $tables[] = $tbl[0];
         if (in_array('exceptions', $tables)) return true;
         else return false;
     }

--- a/lib/ControlPanel.php
+++ b/lib/ControlPanel.php
@@ -145,9 +145,9 @@ class ControlPanel
         $uIDName = $this->getPostValue('uIDName');
         $sql = $this->getTablesSQL(sprintf('%s = %d', addslashes($uIDName), addslashes($uID)));
         $rs = $this->_db->query($sql);
-        if ($rs && mysql_num_rows($rs) > 0)
+        if ($rs && mysqli_num_rows($rs) > 0)
         {
-            $row = mysql_fetch_array($rs, MYSQL_ASSOC);
+            $row = mysqli_fetch_array($rs, MYSQL_ASSOC);
             if (!$row)
             {
                 return $this->getException('Bad or expired identifier', 'The operation you attempted cannot complete '
@@ -206,7 +206,7 @@ class ControlPanel
                     . 'because the unique identifier no longer exists. Did you perhaps use your browser\'s <b>back</b> '
                     . 'button?');
             }
-            $row = mysql_fetch_array($rs, MYSQL_ASSOC);
+            $row = mysqli_fetch_array($rs, MYSQL_ASSOC);
             if (!$row)
             {
                 return $this->getListView();
@@ -415,9 +415,9 @@ class ControlPanel
                         }
                         else
                         {
-                            $updatedRows += mysql_affected_rows();
+                            $updatedRows += mysqli_affected_rows($this->_db->getConnection());
                             if ($addRecord && $callBackPrimaryKey)
-                                $row[$callBackPrimaryKey] = mysql_insert_id();
+                                $row[$callBackPrimaryKey] = mysqli_insert_id($this->_db->getConnection());
                             if ($callBack)
                                 $callBack($row);
                         }
@@ -814,7 +814,7 @@ class ControlPanel
             if ($currencySql != '')
             {
                 $rs = $this->_db->query($sql = $this->getTablesSQL($searchSql, '', $currencySql));
-                $currencySums = mysql_fetch_array($rs, MYSQL_ASSOC);
+                $currencySums = mysqli_fetch_array($rs, MYSQLI_ASSOC);
             }
         }
 
@@ -834,7 +834,7 @@ class ControlPanel
 
         // get the records count
         $rs = $this->_db->query($sql = $this->getTablesSQL($searchSql, '', 'COUNT(*)'));
-        $rsCount = intval(mysql_result($rs, 0, 0));
+        $rsCount = intval(mysqli_fetch_row($rs);
         $numPages = ceil($rsCount / $pager_ResultsPerPage);
         if ($pager_CurrentPage >= $numPages) $pager_CurrentPage = $numPages - 1;
         if ($pager_CurrentPage < 0) $pager_CurrentPage = 0;
@@ -859,7 +859,7 @@ class ControlPanel
         $fieldOffset = true;
 
         $rowNum = 0;
-        while ($row = mysql_fetch_array($rs, MYSQL_ASSOC))
+        while ($row = mysqli_fetch_array($rs, MYSQLI_ASSOC))
         {
             $numColumns = 0;
             $infoHtml .= "<tr>\n";
@@ -1443,7 +1443,7 @@ class ControlPanel
         $this->_tables[$name]['fields'] = array();
         // Fetch the fields from the table
         $rs = $this->_db->query('SHOW FIELDS FROM ' . $name);
-        while ($row = mysql_fetch_array($rs, MYSQL_ASSOC))
+        while ($row = mysqli_fetch_array($rs, MYSQLI_ASSOC))
         {
             $this->_tables[$name]['fields'][$row['Field']] = array(
                 'type' => $row['Type'],

--- a/lib/DatabaseConnection.php
+++ b/lib/DatabaseConnection.php
@@ -108,12 +108,12 @@ class DatabaseConnection
      */
     public function connect()
     {
-        $this->_connection = @mysql_connect(
+        $this->_connection = @mysqli_connect(
             DATABASE_HOST, DATABASE_USER, DATABASE_PASS
         );
         if (!$this->_connection)
         {
-            $error = mysql_error();
+            $error = mysqli_error($this->_connection);
 
             die(
                 '<!-- NOSPACEFILTER --><p style="background: #ec3737; padding:'
@@ -123,11 +123,11 @@ class DatabaseConnection
             );
             return false;
         }
-        mysql_set_charset(SQL_CHARACTER_SET, $this->_connection);
-        $isDBSelected = @mysql_select_db(DATABASE_NAME, $this->_connection);
+        mysqli_set_charset($this->_connection, SQL_CHARACTER_SET);
+        $isDBSelected = @mysqli_select_db($this->_connection, DATABASE_NAME);
         if (!$isDBSelected)
         {
-            $error = mysql_error($this->_connection);
+            $error = mysqli_error($this->_connection);
 
             die(
                 '<!-- NOSPACEFILTER --><p style="background: #ec3737; '
@@ -168,10 +168,10 @@ class DatabaseConnection
         /* Don't limit the execution time of queries. */
         set_time_limit(0);
 
-        $this->_queryResult = mysql_query($query, $this->_connection);
+        $this->_queryResult = mysqli_query($this->_connection, $query);
         if (!$this->_queryResult && !$ignoreErrors)
         {
-            $error = mysql_error($this->_connection);
+            $error = mysqli_error($this->_connection);
 
             echo (
                 '<!-- NOSPACEFILTER --><p style="background: #ec3737; padding:'
@@ -239,7 +239,7 @@ class DatabaseConnection
             $this->query($query);
         }
 
-        $numRows = mysql_num_rows($this->_queryResult);
+        $numRows = mysqli_num_rows($this->_queryResult);
         if ($numRows === false)
         {
             return false;
@@ -253,7 +253,8 @@ class DatabaseConnection
             return false;
         }
 
-        return mysql_result($this->_queryResult, $row, $column);
+		mysqli_data_seek($this->_queryResult, $row);
+        return mysqli_fetch_row($this->_queryResult);
     }
 
     /**
@@ -290,7 +291,7 @@ class DatabaseConnection
             $this->query($query);
         }
 
-        $recordSet = mysql_fetch_assoc($this->_queryResult);
+        $recordSet = mysqli_fetch_assoc($this->_queryResult);
 
         if (empty($recordSet))
         {
@@ -336,7 +337,7 @@ class DatabaseConnection
         $recordSetArray = array();
 
         /* Store all rows in $recordSetArray; */
-        while (($recordSet = mysql_fetch_assoc($this->_queryResult)))
+        while (($recordSet = mysqli_fetch_assoc($this->_queryResult)))
         {
             $recordSetArray[] = $recordSet;
         }
@@ -358,7 +359,7 @@ class DatabaseConnection
             $this->query($query);
         }
 
-        return mysql_num_rows($this->_queryResult);
+        return mysqli_num_rows($this->_queryResult);
     }
 
     /**
@@ -369,7 +370,7 @@ class DatabaseConnection
      */
     public function isEOF()
     {
-        $rowCount = mysql_num_rows($this->_queryResult);
+        $rowCount = mysqli_num_rows($this->_queryResult);
         if (!$rowCount)
         {
             return true;
@@ -452,7 +453,7 @@ class DatabaseConnection
         // user input. For instance see: 
         // https://johnroach.info/2011/02/17/why-mysql_real_escape_string-isnt-enough-to-stop-sql-injection-attacks/
         // To be replaced with Symfony's stack
-        return mysql_real_escape_string($string, $this->_connection);
+        return mysqli_real_escape_string($this->_connection, $string);
     }
 
     /**
@@ -551,7 +552,7 @@ class DatabaseConnection
      */
     public function getError()
     {
-        return mysql_error($this->_connection);
+        return mysqli_error($this->_connection);
     }
 
     /**
@@ -565,7 +566,7 @@ class DatabaseConnection
      */
     public function getLastInsertID()
     {
-        return @mysql_insert_id($this->_connection);
+        return @mysqli_insert_id($this->_connection);
     }
 
     /**
@@ -577,7 +578,7 @@ class DatabaseConnection
      */
     public function getAffectedRows()
     {
-        return @mysql_affected_rows($this->_connection);
+        return @mysqli_affected_rows($this->_connection);
     }
 
     /**

--- a/lib/InstallationTests.php
+++ b/lib/InstallationTests.php
@@ -226,17 +226,17 @@ class InstallationTests
     /* Is MySQL extension loaded?. */
     public static function checkMySQLExtension()
     {
-        if (!self::DEBUG_FAIL && extension_loaded('mysql') && function_exists('mysql_connect'))
+        if (!self::DEBUG_FAIL && extension_loaded('mysqli') && function_exists('mysqli_connect'))
         {
-            echo '<tr class="pass"><td>PHP MySQL extension (mysql) is loaded.</td></tr>';
+            echo '<tr class="pass"><td>PHP MySQLi extension (mysqli) is loaded.</td></tr>';
             return true;
         }
 
-        echo '<tr class="fail"><td><strong>PHP MySQL extension (mysql) is not loaded.</strong><br />'
+        echo '<tr class="fail"><td><strong>PHP MySQL extension (mysqli) is not loaded.</strong><br />'
             . 'Check your settings in php.ini.<br /><br />'
             . 'Under certain Linux / BSD distributions, the PHP MySQL extension is a separate package.<br /><br />'
-            . '<strong>Debian:</strong> Run "apt-get install php5-mysql" and restart your webserver.<br /><br />'
-            . '<strong>FreeBSD:</strong> Install the php5-mysql port, or configure MySQL support in the '
+            . '<strong>Debian:</strong> Run "apt-get install php5-mysqli" and restart your webserver.<br /><br />'
+            . '<strong>FreeBSD:</strong> Install the php5-mysqli port, or configure MySQL support in the '
             . 'php-extensions port and restart your webserver.</td></tr>';
         return false;
     }
@@ -387,11 +387,12 @@ class InstallationTests
     public static function checkMySQL($host, $user, $pass, $name)
     {
         /* Check MySQL connection. */
-        if (self::DEBUG_FAIL || !@mysql_connect($host, $user, $pass))
+		$db = @mysqli_connect($host, $user, $pass);
+        if (self::DEBUG_FAIL || !$db)
         {
             echo sprintf(
                 '<tr class="fail"><td>Cannot connect to database.<pre class="fail">%s</pre></td></tr>',
-                mysql_error()
+                mysqli_error($db)
             );
             return false;
         }
@@ -399,18 +400,18 @@ class InstallationTests
         echo '<tr class="pass"><td>MySQL connection was successful.</td></tr>';
 
         /* Check MySQL version number. */
-        if (!self::_checkMySQLVersion())
+        if (!self::_checkMySQLVersion($db))
         {
             return false;
         }
 
         /* Try to switch to the CATS database. */
-        if (!@mysql_select_db($name))
+        if (!@mysqli_select_db($db, $name))
         {
             echo sprintf(
                 '<tr class="fail"><td>Failed to select database \'%s\'.<pre class="fail">%s</pre></td></tr>',
                 $name,
-                mysql_error()
+                mysqli_error($db)
             );
             return false;
         }
@@ -421,11 +422,11 @@ class InstallationTests
         );
 
         /* Check CREATE TABLE permissions. */
-        $queryResult = @mysql_query('CREATE TABLE `testtable` (`id` int(11) NOT NULL default \'0\') ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;');
+        $queryResult = @mysqli_query($db, 'CREATE TABLE `testtable` (`id` int(11) NOT NULL default \'0\') ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;');
         if (!$queryResult)
         {
-            mysql_query('DROP TABLE testtable');
-            $queryResult = @mysql_query('CREATE TABLE `testtable` (`id` int(11) NOT NULL default \'0\') ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;');
+            mysqli_query($db, 'DROP TABLE testtable');
+            $queryResult = @mysqli_query($db, 'CREATE TABLE `testtable` (`id` int(11) NOT NULL default \'0\') ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;');
         }
         if (!$queryResult)
         {
@@ -444,7 +445,7 @@ class InstallationTests
         );
 
         /* Check INSERT permissions. */
-        if (!@mysql_query('INSERT INTO testtable (id) VALUES (1)'))
+        if (!@mysqli_query($db, 'INSERT INTO testtable (id) VALUES (1)'))
         {
             echo sprintf(
                 '<tr class="fail"><td>Cannot insert into \'testtable\' table. Please verify that '
@@ -459,7 +460,7 @@ class InstallationTests
         echo '<tr class="pass"><td>Can insert into \'testtable\' table.</td></tr>';
 
         /* Check UPDATE permissions. */
-        if (!@mysql_query('UPDATE testtable SET id = 5 WHERE id = 1'))
+        if (!@mysqli_query($db, 'UPDATE testtable SET id = 5 WHERE id = 1'))
         {
             echo sprintf(
                 '<tr class="fail"><td>Cannot update \'testtable\' table. Please verify that '
@@ -474,7 +475,7 @@ class InstallationTests
         echo '<tr class="pass"><td>Can update \'testtable\' table.</td></tr>';
 
         /* Check DELETE permissions. */
-        if (!@mysql_query('DELETE FROM testtable WHERE id = 5'))
+        if (!@mysqli_query($db, 'DELETE FROM testtable WHERE id = 5'))
         {
             echo sprintf(
                 '<tr class="fail"><td>Cannot delete from \'testtable\' table. Please verify that '
@@ -489,7 +490,7 @@ class InstallationTests
         echo '<tr class="pass"><td>Can delete from \'testtable\' table.</td></tr>';
 
         /* Check DROP TABLES permissions. */
-        if (!@mysql_query('DROP TABLE testtable'))
+        if (!@mysqli_query($db, 'DROP TABLE testtable'))
         {
             echo sprintf(
                 '<tr class="fail"><td>Cannot drop table \'testtable\'. Please verify that '
@@ -758,20 +759,21 @@ class InstallationTests
     }
 
 
-    private static function _checkMySQLVersion()
+    private static function _checkMySQLVersion($db)
     {
         /* Check MySQL version. */
-        $queryResult = mysql_query('SELECT VERSION()');
+        $queryResult = mysqli_query($db, 'SELECT VERSION()');
         if (!$queryResult)
         {
             echo sprintf(
                 '<tr class="fail"><td>Cannot retrieve MySQL version number. <pre class="fail">%s</pre></td></tr>',
-                mysql_error()
+                mysqli_error($db)
             );
             return false;
         }
 
-        $row = mysql_fetch_row($queryResult);
+        $row = mysqli_fetch_row($queryResult);
+
         $versionParts = explode('-', $row[0]);
         $version = $versionParts[0];
 

--- a/modules/install/OptionalComponents.php
+++ b/modules/install/OptionalComponents.php
@@ -41,7 +41,7 @@ $optionalComponents['usZipCodes']['removeCode'] = '
 $optionalComponents['usZipCodes']['detectCode'] = '
     $rs = MySQLQuery(\'SELECT * FROM zipcodes\');
 
-    if ($rs && mysql_fetch_row($rs))
+    if ($rs && mysqli_fetch_row($rs))
     {
         return true;
     }

--- a/modules/install/ajax/ui.php
+++ b/modules/install/ajax/ui.php
@@ -161,8 +161,8 @@ switch ($action)
         if (isset($tables['settings']))
         {
             $rs = MySQLQuery('SELECT value FROM settings WHERE setting = "fromAddress" LIMIT 1');
-            if (mysql_num_rows($rs) > 0)
-                $mailFromAddress = mysql_result($rs, 0, 0);
+            if (mysqli_num_rows($rs) > 0)
+                $mailFromAddress = mysqli_fetch_row($rs);
         }
 
         echo '
@@ -175,7 +175,7 @@ switch ($action)
                 document.getElementById(\'mailSmtpPort\').value = \'' . htmlspecialchars(MAIL_SMTP_PORT) . '\';
                 document.getElementById(\'mailSmtpUsername\').value = \'' . htmlspecialchars(MAIL_SMTP_USER) . '\';
                 document.getElementById(\'mailSmtpPassword\').value = \'' . htmlspecialchars(MAIL_SMTP_PASS) . '\';
-                document.getElementById(\'mailFromAddress\').value = \'' . htmlspecialchars($mailFromAddress) . '\';
+                document.getElementById(\'mailFromAddress\').value = \'' . htmlspecialchars($mailFromAddress[0]) . '\';
                 changeMailForm();
             </script>';
         break;
@@ -458,7 +458,7 @@ switch ($action)
         $rs = MySQLQuery('SELECT date_format_ddmmyy FROM site', true);
         if ($rs)
         {
-            $record = mysql_fetch_assoc($rs);
+            $record = mysqli_fetch_assoc($rs);
         }
         else
         {
@@ -568,7 +568,7 @@ switch ($action)
 
         $rs = MySQLQuery('SELECT * FROM candidate', true);
         $fields = array();
-        while ($meta = @mysql_fetch_field($rs))
+        while ($meta = @mysqli_fetch_field($rs))
         {
             if ($meta)
             {
@@ -755,7 +755,7 @@ switch ($action)
         //Check if we need to update from 0.6.0 to 0.7.0
         $tables = array();
         $result = MySQLQuery(sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME));
-        while ($row = mysql_fetch_array($result, MYSQL_NUM))
+        while ($row = mysqli_fetch_array($result, MYSQLI_NUM))
         {
             $tables[$row[0]] = true;
         }
@@ -848,7 +848,7 @@ switch ($action)
         $revision = 0;
         $rs = MySQLQuery('SELECT * FROM candidate', true);
         $fields = array();
-        while ($meta = mysql_fetch_field($rs))
+        while ($meta = mysqli_fetch_field($rs))
         {
             $fields[$meta->name] = true;
         }
@@ -966,7 +966,7 @@ switch ($action)
         // If this is an existing database, just set all the fromAddress settings to new
         MySQLQuery(sprintf('UPDATE settings SET value = "%s" WHERE setting = "fromAddress"', $fromAddress));
         // This is a new install, insert a settings value for each site in the database
-        if(mysql_affected_rows() == 0)
+        if(mysqli_affected_rows($mySQLConnection) == 0)
         {
             // Insert a "fromAddress" = $fromAddress for each site
             MySQLQuery(sprintf(
@@ -1027,7 +1027,7 @@ switch ($action)
 
         /* Determine if a default user is set. */
         $rs = MySQLQuery("SELECT * FROM user WHERE user_name = 'admin' AND password = 'cats'");
-        if ($rs && mysql_fetch_row($rs))
+        if ($rs && mysqli_fetch_row($rs))
         {
             //Default user set
             echo '<script type="text/javascript">document.location.href="index.php?defaultlogin=true";</script>';
@@ -1047,7 +1047,7 @@ function MySQLConnect()
 {
     global $tables, $mySQLConnection;
 
-    $mySQLConnection = @mysql_connect(
+    $mySQLConnection = @mysqli_connect(
         DATABASE_HOST, DATABASE_USER, DATABASE_PASS
     );
 
@@ -1056,7 +1056,7 @@ function MySQLConnect()
         die(
             '<p style="background: #ec3737; padding: 4px; margin-top: 0; font:'
             . ' normal normal bold 12px/130% Arial, Tahoma, sans-serif;">Error '
-            . " Connecting to Database</p><pre>\n\n" . mysql_error() . "</pre>\n\n"
+            . " Connecting to Database</p><pre>\n\n" . mysqli_error($mySQLConnection) . "</pre>\n\n"
         );
         return false;
     }
@@ -1065,16 +1065,16 @@ function MySQLConnect()
     /* Create an array of all tables in the database. */
     $tables = array();
     $result = MySQLQuery(sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME));
-    while ($row = mysql_fetch_row($result))
+    while ($row = mysqli_fetch_row($result))
     {
         $tables[$row[0]] = true;
     }
 
     /* Select CATS database. */
-    $isDBSelected = @mysql_select_db(DATABASE_NAME, $mySQLConnection);
+    $isDBSelected = @mysqli_select_db($mySQLConnection, DATABASE_NAME);
     if (!$isDBSelected)
     {
-        $error = mysql_error($mySQLConnection);
+        $error = mysqli_error($mySQLConnection);
 
         die(
             '<p style="background: #ec3737; padding: 4px; margin-top: 0; font:'
@@ -1089,10 +1089,10 @@ function MySQLQuery($query, $ignoreErrors = false)
 {
     global $mySQLConnection;
 
-    $queryResult = mysql_query($query, $mySQLConnection);
+    $queryResult = mysqli_query($mySQLConnection, $query);
     if (!$queryResult && !$ignoreErrors)
     {
-        $error = mysql_error($mySQLConnection);
+        $error = mysqli_error($mySQLConnection);
 
         if ($error == 'Query was empty')
         {

--- a/modules/install/backupDB.php
+++ b/modules/install/backupDB.php
@@ -79,11 +79,10 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
 
     $text = '';
 
-    $result = mysql_query(
-        sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME),
-        $connection
+    $result = mysqli_query($connection,
+        sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME)
     );
-    while ($row = mysql_fetch_array($result, MYSQL_NUM))
+    while ($row = mysqli_fetch_array($result, MYSQLI_NUM))
     {
         $tables[] = $row[0];
     }
@@ -108,10 +107,10 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
 
         $text .= 'DROP TABLE IF EXISTS `' . $table . '`((ENDOFQUERY))'."\n";
         $sql = 'SHOW CREATE TABLE ' . $table;
-        $rs = mysql_query($sql, $connection);
+        $rs = mysqli_query($connection, $sql);
         if ($rs)
         {
-            if ($row = mysql_fetch_assoc($rs))
+            if ($row = mysqli_fetch_assoc($rs))
             {
                 $text .= $row['Create Table'] . "((ENDOFQUERY))\n\n";
             }
@@ -132,8 +131,8 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
 
         $isSiteIdColumn = false;
         $sql = sprintf("SHOW COLUMNS FROM %s", $table);
-        $rs = mysql_query($sql, $connection);
-        while ($recordSet = mysql_fetch_assoc($rs))    
+        $rs = mysqli_query($connection, $sql);
+        while ($recordSet = mysqli_fetch_assoc($rs))    
         {
             if ($recordSet['Field'] == 'site_id')
             {
@@ -150,9 +149,9 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
             $sql = 'SELECT * FROM ' . $table . '';
         }
 
-        $rs = mysql_query($sql, $connection);
+        $rs = mysqli_query($sql, $connection);
         $index = 0;
-        while ($recordSet = mysql_fetch_assoc($rs))
+        while ($recordSet = mysqli_fetch_assoc($rs))
         {
             $continue = true;
 
@@ -228,7 +227,7 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
                 $i = 0;
                 foreach ($recordSet as $field)
                 {
-                    $text .= "'".mysql_real_escape_string($field)."'";
+                    $text .= "'".mysqli_real_escape_string($connection, $field)."'";
                     $i++;
                     if ($i != count($recordSet))
                     {

--- a/modules/install/scripts/114.php
+++ b/modules/install/scripts/114.php
@@ -51,7 +51,7 @@ function getAllFilesInDirectory($directory)
 function update_114($db)
 {
     $attachments = $db->query('SELECT * FROM attachment');
-    while ($attachment = mysql_fetch_assoc($attachments))
+    while ($attachment = mysqli_fetch_assoc($attachments))
     {
         $newFilename = $attachment['stored_filename'];
         for ($i = 0; $i < strlen($newFilename); $i++)

--- a/modules/install/scripts/150.php
+++ b/modules/install/scripts/150.php
@@ -53,7 +53,7 @@ function update_150($db)
     global $badFileExtensions;
 
     $attachments = $db->query('SELECT * FROM attachment');
-    while ($attachment = mysql_fetch_assoc($attachments))
+    while ($attachment = mysqli_fetch_assoc($attachments))
     {
         $fileExtension = substr(
             $attachment['stored_filename'],

--- a/modules/settings/ajax/backup.php
+++ b/modules/settings/ajax/backup.php
@@ -231,12 +231,12 @@ if ($action == 'backup')
             site_id = %s",
         $siteID
     );
-    $queryResult = mysql_query($sql);
-    $totalAttachments = mysql_num_rows($queryResult);
+    $queryResult = mysqli_query($db, $sql);
+    $totalAttachments = mysqli_num_rows($queryResult);
 
     /* Add each attachment to the zip file. */
     $attachmentCount = 0;
-    while ($row = mysql_fetch_assoc($queryResult))
+    while ($row = mysqli_fetch_assoc($queryResult))
     {
         ++$attachmentCount;
 

--- a/modules/tests/waitForDb.php
+++ b/modules/tests/waitForDb.php
@@ -6,12 +6,12 @@ $canConnectAndSelectDb = false;
 $count = 30;
 while (!$canConnectAndSelectDb && $count > 0)
 {
-    $connection = @mysql_connect(
+    $connection = @mysqli_connect(
         DATABASE_HOST, DATABASE_USER, DATABASE_PASS
     );
     if ($connection)
     {
-        $isDBSelected = @mysql_select_db(DATABASE_NAME, $connection);
+        $isDBSelected = @mysqli_select_db(DATABASE_NAME, $connection);
         if ($isDBSelected)
         {
             $canConnectAndSelectDb = true;

--- a/rebuild_old_docs.php
+++ b/rebuild_old_docs.php
@@ -14,14 +14,15 @@
 require_once 'config.php';
 
 function rebuild_old_docs() {
-
-    $result = mysql_query('SELECT * FROM `attachment` WHERE `text` IS NULL');
+	
+	global $con;
+    $result = mysqli_query($con, 'SELECT * FROM `attachment` WHERE `text` IS NULL');
 
     include_once('./lib/DocumentToText.php');
 
     $countOK = 0;
     $countError = 0;
-    while ($attachment = mysql_fetch_object($result)) {
+    while ($attachment = mysqli_fetch_object($result)) {
         $doc2txt = new DocumentToText();
         $doc2txt->convert('attachments/' . $attachment->directory_name . $attachment->stored_filename,
                 $doc2txt->getDocumentType('attachments/' . $attachment->directory_name . $attachment->stored_filename));
@@ -35,10 +36,10 @@ function rebuild_old_docs() {
             $extractedText = $doc2txt->getString();
             print('File ' . $attachment->stored_filename." reindexed.\n");
             $sql = 'UPDATE `attachment` SET `text` = \'' . addslashes($extractedText) . '\', `md5_sum_text` = \'' . md5($extractedText) . '\'  WHERE `attachment_id` = ' . $attachment->attachment_id;
-            $upd = mysql_query($sql);
+            $upd = mysqli_query($con, $sql);
             if (!$upd) {
                $countError++;
-                print('DB error: ' . mysql_error());
+                print('DB error: ' . mysqli_error($con));
             } else {
                $countOK++;
             }
@@ -50,12 +51,12 @@ function rebuild_old_docs() {
 
 
 //$con = mysql_connect("localhost","root","root");
-$con = mysql_connect(DATABASE_HOST, DATABASE_USER, DATABASE_PASS);
+$con = mysqli_connect(DATABASE_HOST, DATABASE_USER, DATABASE_PASS);
 if (!$con)
 {
-  die('Could not connect: ' . mysql_error());
+  die('Could not connect: ' . mysqli_error($co$conn));
 }
-mysql_select_db(DATABASE_NAME, $con);
+mysqli_select_db(DATABASE_NAME, $con);
 
 rebuild_old_docs();
 ?>

--- a/scripts/makeBackup.php
+++ b/scripts/makeBackup.php
@@ -243,11 +243,11 @@ function dumpAttachments($db, $directory, $siteID)
         $siteID
     );
 
-    $queryResult = mysql_query($sql);
-    $totalAttachments = mysql_num_rows($queryResult);
+    $queryResult = mysqli_query($db, $sql);
+    $totalAttachments = mysqli_num_rows($queryResult);
 
     /* Add each attachment to the zip file. */
-    while ($row = mysql_fetch_assoc($queryResult))
+    while ($row = mysqli_fetch_assoc($queryResult))
     {
         $relativePath = sprintf(
             'attachments/%s/%s',

--- a/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
+++ b/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
@@ -173,7 +173,7 @@ class DatabaseConnectionTest extends DatabaseTestCase
             'SELECT query should succeed'
             );
         $this->assertEquals(
-            mysql_num_rows($queryResult),
+            mysqli_num_rows($queryResult),
             1,
             '1 row should be returned'
             );

--- a/src/OpenCATS/Tests/IntegrationTests/DatabaseTestCase.php
+++ b/src/OpenCATS/Tests/IntegrationTests/DatabaseTestCase.php
@@ -17,7 +17,7 @@ class DatabaseTestCase extends TestCase
 
         include_once('./config.php');
         include_once('./lib/DatabaseConnection.php');
-        $mySQLConnection = @mysql_connect(
+        $mySQLConnection = @mysqli_connect(
             DATABASE_HOST, DATABASE_USER, DATABASE_PASS
             );
         if (!$mySQLConnection)
@@ -27,7 +27,7 @@ class DatabaseTestCase extends TestCase
         $this->mySQLQuery('DROP DATABASE IF EXISTS ' . DATABASE_NAME);
         $this->mySQLQuery('CREATE DATABASE ' . DATABASE_NAME);
 
-        @mysql_select_db(DATABASE_NAME, $mySQLConnection);
+        @mysqli_select_db(DATABASE_NAME, $mySQLConnection);
 
         $this->mySQLQueryMultiple(file_get_contents('db/cats_schema.sql'), ";\n");
     }
@@ -54,10 +54,10 @@ class DatabaseTestCase extends TestCase
     {
         global $mySQLConnection;
 
-        $queryResult = mysql_query($query, $mySQLConnection);
+        $queryResult = mysqli_query($mySQLConnection, $query);
         if (!$queryResult && !$ignoreErrors)
         {
-            $error = mysql_error($mySQLConnection);
+            $error = mysqli_error($mySQLConnection);
 
             if ($error == 'Query was empty')
             {


### PR DESCRIPTION
Fixes #171 

This is a quick fix to make OpenCATS compatible with PHP7. Please note that this PR is just for mysql and I haven't touched any other methods deprecated in PHP-7. This is tested only in PHP-7.0 and MariaDB-10. I didn't execute any automated test cases. I hope it will be take care in travis.

There are several things to be improved:
1. Use Object Oriented methods for mysqli or move the entire DB stuff to PDO.
2. The DB connection is instantiated in multiple files. This needs to be unified to use a single DB object. This will also make it easy to fix the binding methods.