### PR TITLE
Fixes Non-static method

### DIFF
--- a/lib/FileUtility.php
+++ b/lib/FileUtility.php
@@ -163,7 +163,7 @@ class FileUtility
      *                text?
      * @return string Safe filename.
      */
-    public function makeSafeFilename($filename)
+    public static function makeSafeFilename($filename)
     {
         /* Strip out *nix directories. */
         $filenameParts = explode('/', $filename);


### PR DESCRIPTION
Strict standards: Non-static method FileUtility::makeSafeFilename()