### PR TITLE
Corrected case in call of FileUtility

### DIFF
--- a/modules/settings/SettingsUI.php
+++ b/modules/settings/SettingsUI.php
@@ -2125,7 +2125,7 @@ class SettingsUI extends UserInterface
 
         foreach ($attachmentsRS as $index => $data)
         {
-            $attachmentsRS[$index]['fileSize'] = fileUtility::sizeToHuman(
+            $attachmentsRS[$index]['fileSize'] = FileUtility::sizeToHuman(
                 filesize($data['retrievalURLLocal']), 2, 1
             );
         }


### PR DESCRIPTION
Resolves #36
this issue can now be closed as the underlying method is now static https://github.com/opencats/OpenCATS/blob/master/lib/FileUtility.php#L422