### PR TITLE
Make backup resilient to missing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docker/data/*
 docker/persist/*
 vendor/*
 attachments/*
+temp/*

--- a/modules/settings/ajax/backup.php
+++ b/modules/settings/ajax/backup.php
@@ -239,6 +239,23 @@ if ($action == 'backup')
     while ($row = mysql_fetch_assoc($queryResult))
     {
         ++$attachmentCount;
+        $relativePath = sprintf(
+            'attachments/%s/%s',
+            $row['directory_name'],
+            $row['stored_filename']
+        );
+        if (!file_exists($relativePath)) {
+            setStatusBackup(
+                sprintf(
+                    'Skipping attachment that\'s missing on the file system: %s (%s of %s files processed)...',
+                    $relativePath,
+                    $attachmentCount,
+                    $totalAttachments
+                ),
+                ($attachmentCount / $totalAttachments)
+            );
+            continue;
+        }
 
         setStatusBackup(
             sprintf(
@@ -249,11 +266,7 @@ if ($action == 'backup')
             ($attachmentCount / $totalAttachments)
         );
 
-        $relativePath = sprintf(
-            'attachments/%s/%s',
-            $row['directory_name'],
-            $row['stored_filename']
-        );
+
         
         $attachmentID = $row['attachment_id'];
         

--- a/modules/settings/ajax/backup.php
+++ b/modules/settings/ajax/backup.php
@@ -247,7 +247,7 @@ if ($action == 'backup')
         if (!file_exists($relativePath)) {
             setStatusBackup(
                 sprintf(
-                    'Skipping attachment that\'s missing on the file system: %s (%s of %s files processed)...',
+                    '%s - Skipping attachment as it\'s missing on the file system (%s of %s files processed)...',
                     $relativePath,
                     $attachmentCount,
                     $totalAttachments
@@ -259,15 +259,13 @@ if ($action == 'backup')
 
         setStatusBackup(
             sprintf(
-                'Adding attachments (%s of %s files processed)...',
+                '%s - Adding attachments (%s of %s files processed)...',
+                $relativePath,
                 $attachmentCount,
                 $totalAttachments
             ),
             ($attachmentCount / $totalAttachments)
         );
-
-
-        
         $attachmentID = $row['attachment_id'];
         
         if (!eval(Hooks::get('FORCE_ATTACHMENT_LOCAL'))) return;


### PR DESCRIPTION
Backup is failing on some instances when an attachment is on the db but it's missing in the file system.

This PR makes the backup code more resilient to this issue and proceed with the backup ignoring this file.

We should also make a tool to remove orphaned attachments #259. 

Fixes #253 