### PR TITLE
php5.5 compatibility in ACL.php

### DIFF
--- a/lib/ACL.php
+++ b/lib/ACL.php
@@ -52,28 +52,29 @@ class ACL
             return $defaultAccessLevel;
         }
 
+        $aclmap = ACCESS_LEVEL_MAP;
         $userCategory = ACL::CATEGORY_EMPTY;
         if( isset($userCategories) && count($userCategories) > 0 && isset($userCategories[0]) )
         {
             // for now, only first category is used for evalualtion
             $userCategory = $userCategories[0];
         }
-        if( NULL !== ACCESS_LEVEL_MAP[$userCategory][$securedObjectName])
+        if( NULL !== $aclmap[$userCategory][$securedObjectName])
         {
-            return ACCESS_LEVEL_MAP[$userCategory][$securedObjectName];
+            return $aclmap[$userCategory][$securedObjectName];
         }
 
         while(($pos = strrpos($securedObjectName, ".")) !== false)
         {
             $securedObjectName = substr($securedObjectName, 0, $pos);
-            if( NULL !== ACCESS_LEVEL_MAP[$userCategory][$securedObjectName])
+            if( NULL !== $aclmap[$userCategory][$securedObjectName])
             {
-                return ACCESS_LEVEL_MAP[$userCategory][$securedObjectName];
+                return $aclmap[$userCategory][$securedObjectName];
             }
         }
-        if( NULL !== ACCESS_LEVEL_MAP[$userCategory][ACL::SECOBJ_ROOT])
+        if( NULL !== $aclmap[$userCategory][ACL::SECOBJ_ROOT])
         {
-            return ACCESS_LEVEL_MAP[$userCategory][ACL::SECOBJ_ROOT];
+            return $aclmap[$userCategory][ACL::SECOBJ_ROOT];
         }
         return $defaultAccessLevel;
     }


### PR DESCRIPTION
resolves #264 

fixed code in ACL.php to be compatible with php5.5.

_example in config.php is not php5.5 compatible_
