### PR TITLE
Fix insecure SMTP

### DIFF
--- a/lib/Mailer.php
+++ b/lib/Mailer.php
@@ -324,6 +324,10 @@ class Mailer
                 $this->_mailer->Host   = MAIL_SMTP_HOST;
                 $this->_mailer->Port   = MAIL_SMTP_PORT;
                 $this->_mailer->SMTPSecure  = MAIL_SMTP_SECURE;
+                if (!MAIL_SMTP_SECURE)
+                {
+                    $this->_mailer->SMTPAutoTLS = false;
+                }
                 if (MAIL_SMTP_AUTH == true)
                 {
                     $this->_mailer->SMTPAuth = MAIL_SMTP_AUTH;


### PR DESCRIPTION
A past phpmailer update changed to assume to use TLS even if its not enabled. This breaks insecure SMTP connections.