### PR TITLE
Fix deprecated PHP4-style constructors

### DIFF
--- a/ckeditor/ckeditor_php4.php
+++ b/ckeditor/ckeditor_php4.php
@@ -97,7 +97,7 @@ class CKEditor
 	 *
 	 *  @param $basePath (string) URL to the %CKEditor installation directory (optional).
 	 */
-	function CKEditor($basePath = null) {
+	function __construct($basePath = null) {
 		if (!empty($basePath)) {
 			$this->basePath = $basePath;
 		}

--- a/lib/fpdf/fpdf.php
+++ b/lib/fpdf/fpdf.php
@@ -77,7 +77,7 @@ var $PDFVersion;         //PDF version number
 *                               Public methods                                 *
 *                                                                              *
 *******************************************************************************/
-function FPDF($orientation='P',$unit='mm',$format='A4')
+function __construct($orientation='P',$unit='mm',$format='A4')
 {
 	//Some checks
 	$this->_dochecks();

--- a/lib/simpletest/authentication.php
+++ b/lib/simpletest/authentication.php
@@ -29,7 +29,7 @@ class SimpleRealm {
      *    @param SimpleUrl $url    Somewhere in realm.
      *    @access public
      */
-    function SimpleRealm($type, $url) {
+    function __construct($type, $url) {
         $this->type = $type;
         $this->root = $url->getBasePath();
         $this->username = false;
@@ -135,7 +135,7 @@ class SimpleAuthenticator {
      *    Clears the realms.
      *    @access public
      */
-    function SimpleAuthenticator() {
+    function __construct() {
         $this->restartSession();
     }
 

--- a/lib/simpletest/mock_objects.php
+++ b/lib/simpletest/mock_objects.php
@@ -651,7 +651,7 @@ class SimpleMock {
      *    Creates an empty action list and expectation list.
      *    All call counts are set to zero.
      */
-    function SimpleMock() {
+    function __construct() {
         $this->actions = new SimpleCallSchedule();
         $this->expectations = new SimpleCallSchedule();
         $this->call_counts = array();

--- a/lib/simpletest/reflection_php4.php
+++ b/lib/simpletest/reflection_php4.php
@@ -20,7 +20,7 @@ class SimpleReflection {
      *    @param string $interface    Class or interface
      *                                to inspect.
      */
-    function SimpleReflection($interface) {
+    function __construct($interface) {
         $this->_interface = $interface;
     }
 

--- a/lib/simpletest/test/all_tests.php
+++ b/lib/simpletest/test/all_tests.php
@@ -2,7 +2,7 @@
 require_once(dirname(__FILE__) . '/../autorun.php');
 
 class AllTests extends TestSuite {
-    function AllTests() {
+    function __construct() {
         $this->TestSuite('All tests for SimpleTest ' . SimpleTest::getVersion());
         $this->addFile(dirname(__FILE__) . '/unit_tests.php');
         $this->addFile(dirname(__FILE__) . '/shell_test.php');

--- a/lib/simpletest/test/bad_test_suite.php
+++ b/lib/simpletest/test/bad_test_suite.php
@@ -2,7 +2,7 @@
 require_once(dirname(__FILE__) . '/../autorun.php');
 
 class BadTestCases extends TestSuite {
-    function BadTestCases() {
+    function __construct() {
         $this->TestSuite('Two bad test cases');
         $this->addFile(dirname(__FILE__) . '/support/empty_test_file.php');
     }

--- a/lib/simpletest/test/expectation_test.php
+++ b/lib/simpletest/test/expectation_test.php
@@ -80,7 +80,7 @@ class TestOfInequality extends UnitTestCase {
 class RecursiveNasty {
     private $me;
 
-    function RecursiveNasty() {
+    function __construct() {
         $this->me = $this;
     }
 }

--- a/lib/simpletest/test/mock_objects_test.php
+++ b/lib/simpletest/test/mock_objects_test.php
@@ -196,7 +196,7 @@ class TestOfCallSchedule extends UnitTestCase {
 }
 
 class Dummy {
-    function Dummy() {
+    function __construct() {
     }
 
     function aMethod() {
@@ -839,7 +839,7 @@ class TestOfPartialMocks extends UnitTestCase {
 }
 
 class ConstructorSuperClass {
-    function ConstructorSuperClass() { }
+    function __construct() { }
 }
 
 class ConstructorSubClass extends ConstructorSuperClass { }

--- a/lib/simpletest/test/unit_tests.php
+++ b/lib/simpletest/test/unit_tests.php
@@ -8,7 +8,7 @@ require_once(dirname(__FILE__) . '/../web_tester.php');
 require_once(dirname(__FILE__) . '/../extensions/pear_test_case.php');
 
 class UnitTests extends TestSuite {
-    function UnitTests() {
+    function __construct() {
         $this->TestSuite('Unit tests');
         $path = dirname(__FILE__);
         $this->addFile($path . '/errors_test.php');

--- a/lib/simpletest/test/visual_test.php
+++ b/lib/simpletest/test/visual_test.php
@@ -20,7 +20,7 @@ require_once('../xml.php');
 class TestDisplayClass {
     private $a;
 
-    function TestDisplayClass($a) {
+    function __construct($a) {
         $this->a = $a;
     }
 }
@@ -261,7 +261,7 @@ class FailingUnitTestCaseOutput extends UnitTestCase {
 }
 
 class Dummy {
-    function Dummy() {
+    function __construct() {
     }
 
     function a() {

--- a/lib/simpletest/test_case.php
+++ b/lib/simpletest/test_case.php
@@ -484,7 +484,7 @@ class TestSuite {
      *                            of the test.
      *    @access public
      */
-    function TestSuite($label = false) {
+    function __construct($label = false) {
         $this->label = $label;
         $this->test_cases = array();
     }
@@ -619,7 +619,7 @@ class BadTestSuite {
      *                            of the test.
      *    @access public
      */
-    function BadTestSuite($label, $error) {
+    function __construct($label, $error) {
         $this->label = $label;
         $this->error = $error;
     }

--- a/lib/simpletest/xml.php
+++ b/lib/simpletest/xml.php
@@ -299,7 +299,7 @@ class NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingXmlTag($attributes) {
+    function __construct($attributes) {
         $this->name = false;
         $this->attributes = $attributes;
     }
@@ -347,7 +347,7 @@ class NestingMethodTag extends NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingMethodTag($attributes) {
+    function __construct($attributes) {
         $this->NestingXmlTag($attributes);
     }
 
@@ -387,7 +387,7 @@ class NestingCaseTag extends NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingCaseTag($attributes) {
+    function __construct($attributes) {
         $this->NestingXmlTag($attributes);
     }
 
@@ -427,7 +427,7 @@ class NestingGroupTag extends NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingGroupTag($attributes) {
+    function __construct($attributes) {
         $this->NestingXmlTag($attributes);
     }
 
@@ -485,7 +485,7 @@ class SimpleTestXmlParser {
      *    @param SimpleReporter $listener   Listener of tag events.
      *    @access public
      */
-    function SimpleTestXmlParser(&$listener) {
+    function __construct(&$listener) {
         $this->listener = &$listener;
         $this->expat = &$this->createParser();
         $this->tag_stack = array();

--- a/lib/sphinx/sphinxapi.php
+++ b/lib/sphinx/sphinxapi.php
@@ -85,7 +85,7 @@ class SphinxClient
 	/////////////////////////////////////////////////////////////////////////////
 
 	/// create a new client object and fill defaults
-	function SphinxClient ()
+	function __construct ()
 	{
 		$this->_host		= "localhost";
 		$this->_port		= 3312;


### PR DESCRIPTION
I'm interested in getting OpenCATS working on PHP 7+. This is a minor step in that direction to get a feel for how the project wants patches submitted before putting any time into `mysql` or `ereg`.