### PR TITLE
Resolving [most?] PHP 7 compatibility issues

### DIFF
--- a/QueueCLI.php
+++ b/QueueCLI.php
@@ -58,7 +58,9 @@ session_start();
 /* Make sure we aren't getting screwed over by magic quotes. */
 if (get_magic_quotes_runtime())
 {
-    set_magic_quotes_runtime(0);
+    if (function_exists('set_magic_quotes_runtime')) {
+        set_magic_quotes_runtime(0);
+    }
 }
 if (get_magic_quotes_gpc())
 {

--- a/ajax.php
+++ b/ajax.php
@@ -49,7 +49,9 @@ header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 /* Make sure we aren't getting screwed over by magic quotes. */
 if (get_magic_quotes_runtime())
 {
-    set_magic_quotes_runtime(0);
+    if (function_exists('set_magic_quotes_runtime')) {
+        set_magic_quotes_runtime(0);
+    }
 }
 if (get_magic_quotes_gpc())
 {

--- a/ckeditor/ckeditor_php4.php
+++ b/ckeditor/ckeditor_php4.php
@@ -97,7 +97,7 @@ class CKEditor
 	 *
 	 *  @param $basePath (string) URL to the %CKEditor installation directory (optional).
 	 */
-	function CKEditor($basePath = null) {
+	function __construct($basePath = null) {
 		if (!empty($basePath)) {
 			$this->basePath = $basePath;
 		}

--- a/index.php
+++ b/index.php
@@ -90,7 +90,9 @@ function stripslashes_deep($value)
 /* Make sure we aren't getting screwed over by magic quotes. */
 if (get_magic_quotes_runtime())
 {
-    set_magic_quotes_runtime(0);
+    if (function_exists('set_magic_quotes_runtime')) {
+        set_magic_quotes_runtime(0);
+    }
 }
 if (get_magic_quotes_gpc())
 {

--- a/lib/Attachments.php
+++ b/lib/Attachments.php
@@ -993,7 +993,7 @@ class AttachmentCreator
     public function createFromFile($dataItemType, $dataItemID, $filePath,
         $title, $contentType, $extractText, $fileExists)
     {
-        $filePathParts = split('/', $filePath);
+        $filePathParts = explode('/', $filePath);
         $originalFilename = end($filePathParts);
 
         return $this->createGeneric(

--- a/lib/Calendar.php
+++ b/lib/Calendar.php
@@ -952,7 +952,7 @@ class Calendar
         $mailer = new Mailer($siteID, $userID);
 
         $destination = str_replace(',', ';', $destination);
-        $destinations = split(';', $destination);
+        $destinations = explode(';', $destination);
 
         foreach ($destinations as $address)
         {

--- a/lib/ControlPanel.php
+++ b/lib/ControlPanel.php
@@ -147,7 +147,7 @@ class ControlPanel
         $rs = $this->_db->query($sql);
         if ($rs && mysqli_num_rows($rs) > 0)
         {
-            $row = mysqli_fetch_array($rs, MYSQL_ASSOC);
+            $row = mysqli_fetch_array($rs, MYSQLI_ASSOC);
             if (!$row)
             {
                 return $this->getException('Bad or expired identifier', 'The operation you attempted cannot complete '
@@ -206,7 +206,7 @@ class ControlPanel
                     . 'because the unique identifier no longer exists. Did you perhaps use your browser\'s <b>back</b> '
                     . 'button?');
             }
-            $row = mysqli_fetch_array($rs, MYSQL_ASSOC);
+            $row = mysqli_fetch_array($rs, MYSQLI_ASSOC);
             if (!$row)
             {
                 return $this->getListView();

--- a/lib/ControlPanel.php
+++ b/lib/ControlPanel.php
@@ -834,7 +834,7 @@ class ControlPanel
 
         // get the records count
         $rs = $this->_db->query($sql = $this->getTablesSQL($searchSql, '', 'COUNT(*)'));
-        $rsCount = intval(mysqli_fetch_row($rs);
+        $rsCount = intval(mysqli_fetch_row($rs));
         $numPages = ceil($rsCount / $pager_ResultsPerPage);
         if ($pager_CurrentPage >= $numPages) $pager_CurrentPage = $numPages - 1;
         if ($pager_CurrentPage < 0) $pager_CurrentPage = 0;

--- a/lib/ControlPanel.php
+++ b/lib/ControlPanel.php
@@ -358,7 +358,7 @@ class ControlPanel
 
                         if ($this->_insertBoundriesSql != '')
                         {
-                            list($fieldName, $fieldValue) = split('=', $this->_insertBoundriesSql);
+                            list($fieldName, $fieldValue) = explode('=', $this->_insertBoundriesSql);
                             $fieldName = trim($fieldName);
                             $fieldValue = trim($fieldValue);
                         }
@@ -1184,7 +1184,7 @@ class ControlPanel
         switch($fieldData['webFormType'])
         {
             case WFT_CC_EXPIRATION:
-                list($expireMonth, $expireYear) = split('/', $text);
+                list($expireMonth, $expireYear) = explode('/', $text);
                 return '"' . sprintf('%s-%s-01', $expireYear, $expireMonth) . '"';
             case WFT_CC_NUMBER:
                 return '"' . addslashes(EncryptionUtility::encryptCreditCardNumber($text)) . '"';

--- a/lib/Mailer.php
+++ b/lib/Mailer.php
@@ -324,6 +324,10 @@ class Mailer
                 $this->_mailer->Host   = MAIL_SMTP_HOST;
                 $this->_mailer->Port   = MAIL_SMTP_PORT;
                 $this->_mailer->SMTPSecure  = MAIL_SMTP_SECURE;
+                if (!MAIL_SMTP_SECURE)
+                {
+                    $this->_mailer->SMTPAutoTLS = false;
+                }
                 if (MAIL_SMTP_AUTH == true)
                 {
                     $this->_mailer->SMTPAuth = MAIL_SMTP_AUTH;

--- a/lib/XmlJobExport.php
+++ b/lib/XmlJobExport.php
@@ -132,7 +132,7 @@ class XmlTemplate
         );
 
         // Break the template into lines
-        $tplLines = split("\n", $rawTemplate);
+        $tplLines = explode("\n", $rawTemplate);
 
         // Browse the lines looking for section headers like ">>SECTION_HEADER_NAME"
         for ( $i=0; $i<count($tplLines); $i++ )

--- a/lib/artichow/Artichow.class.php
+++ b/lib/artichow/Artichow.class.php
@@ -187,7 +187,7 @@ class awGraph extends awImage {
 				$type = awGraph::cleanGraphCache($file);
 
 				if($type === NULL) {
-					$name = ereg_replace(".*/(.*)\-time", "\\1", $file);
+                    $name = preg_replace('#.*/(.*)\-time#', '$1', $file);
 					awGraph::deleteFromCache($name);
 				}
 

--- a/lib/artichow/Graph.class.php
+++ b/lib/artichow/Graph.class.php
@@ -180,7 +180,7 @@ class awGraph extends awImage {
 			$type = awGraph::cleanGraphCache($file);
 
 			if($type === NULL) {
-				$name = ereg_replace(".*/(.*)\-time", "\\1", $file);
+				$name = preg_replace('#.*/(.*)\-time#', '$1', $file);
 				awGraph::deleteFromCache($name);
 			}
 

--- a/lib/fpdf/font/makefont/makefont.php
+++ b/lib/fpdf/font/makefont/makefont.php
@@ -171,7 +171,7 @@ function MakeFontDescriptor($fm,$symbolic)
 	//StemV
 	if(isset($fm['StdVW']))
 		$stemv=$fm['StdVW'];
-	elseif(isset($fm['Weight']) and eregi('(bold|black)',$fm['Weight']))
+	elseif(isset($fm['Weight']) and preg_match('/(bold|black)/i',$fm['Weight']))
 		$stemv=120;
 	else
 		$stemv=70;

--- a/lib/fpdf/font/makefont/makefont.php
+++ b/lib/fpdf/font/makefont/makefont.php
@@ -298,7 +298,9 @@ function CheckTTF($file)
 function MakeFont($fontfile,$afmfile,$enc='cp1252',$patch=array(),$type='TrueType')
 {
 	//Generate a font definition file
-	set_magic_quotes_runtime(0);
+    if (function_exists('set_magic_quotes_runtime')) {
+        set_magic_quotes_runtime(0);
+    }
 	ini_set('auto_detect_line_endings','1');
 	if($enc)
 	{

--- a/lib/fpdf/fpdf.php
+++ b/lib/fpdf/fpdf.php
@@ -909,7 +909,9 @@ function Image($file,$x,$y,$w=0,$h=0,$type='',$link='')
 		}
 		$type=strtolower($type);
 		$mqr=get_magic_quotes_runtime();
-		set_magic_quotes_runtime(0);
+        if (function_exists('set_magic_quotes_runtime')) {
+            set_magic_quotes_runtime(0);
+        }
 		if($type=='jpg' || $type=='jpeg' || $type=='php')
 			$info=$this->_parsejpg($file);
 		elseif($type=='png')
@@ -922,7 +924,9 @@ function Image($file,$x,$y,$w=0,$h=0,$type='',$link='')
 				$this->Error('Unsupported image type: '.$type);
 			$info=$this->$mtd($file);
 		}
-		set_magic_quotes_runtime($mqr);
+        if (function_exists('set_magic_quotes_runtime')) {
+            set_magic_quotes_runtime($mqr);
+        }
 		$info['i']=count($this->images)+1;
 		$this->images[$file]=$info;
 	}
@@ -1164,7 +1168,9 @@ function _putfonts()
 		$this->_out('endobj');
 	}
 	$mqr=get_magic_quotes_runtime();
-	set_magic_quotes_runtime(0);
+    if (function_exists('set_magic_quotes_runtime')) {
+        set_magic_quotes_runtime(0);
+    }
 	foreach($this->FontFiles as $file=>$info)
 	{
 		//Font file embedding
@@ -1202,7 +1208,9 @@ function _putfonts()
 		$this->_putstream($font);
 		$this->_out('endobj');
 	}
-	set_magic_quotes_runtime($mqr);
+    if (function_exists('set_magic_quotes_runtime')) {
+        set_magic_quotes_runtime($mqr);
+    }
 	foreach($this->fonts as $k=>$font)
 	{
 		//Font objects

--- a/lib/fpdf/fpdf.php
+++ b/lib/fpdf/fpdf.php
@@ -77,7 +77,7 @@ var $PDFVersion;         //PDF version number
 *                               Public methods                                 *
 *                                                                              *
 *******************************************************************************/
-function FPDF($orientation='P',$unit='mm',$format='A4')
+function __construct($orientation='P',$unit='mm',$format='A4')
 {
 	//Some checks
 	$this->_dochecks();

--- a/lib/simpletest/authentication.php
+++ b/lib/simpletest/authentication.php
@@ -29,7 +29,7 @@ class SimpleRealm {
      *    @param SimpleUrl $url    Somewhere in realm.
      *    @access public
      */
-    function SimpleRealm($type, $url) {
+    function __construct($type, $url) {
         $this->type = $type;
         $this->root = $url->getBasePath();
         $this->username = false;
@@ -135,7 +135,7 @@ class SimpleAuthenticator {
      *    Clears the realms.
      *    @access public
      */
-    function SimpleAuthenticator() {
+    function __construct() {
         $this->restartSession();
     }
 

--- a/lib/simpletest/detached.php
+++ b/lib/simpletest/detached.php
@@ -53,7 +53,7 @@ class DetachedTestCase {
      *    @access public
      */
     function run(&$reporter) {
-        $shell = &new SimpleShell();
+        $shell = new SimpleShell();
         $shell->execute($this->command);
         $parser = &$this->createParser($reporter);
         if (! $parser->parse($shell->getOutput())) {
@@ -70,9 +70,9 @@ class DetachedTestCase {
      */
     function getSize() {
         if ($this->size === false) {
-            $shell = &new SimpleShell();
+            $shell = new SimpleShell();
             $shell->execute($this->dry_command);
-            $reporter = &new SimpleReporter();
+            $reporter = new SimpleReporter();
             $parser = &$this->createParser($reporter);
             if (! $parser->parse($shell->getOutput())) {
                 trigger_error('Cannot parse incoming XML from [' . $this->dry_command . ']');

--- a/lib/simpletest/eclipse.php
+++ b/lib/simpletest/eclipse.php
@@ -53,7 +53,7 @@ class EclipseReporter extends SimpleScorer {
      *    @return SimpleSocket      Connection to Eclipse.
      */
     function &createListener($port, $host="127.0.0.1"){
-        $tmplistener = &new SimpleSocket($host, $port, 5);
+        $tmplistener = new SimpleSocket($host, $port, 5);
         return $tmplistener;
     }
 
@@ -64,7 +64,7 @@ class EclipseReporter extends SimpleScorer {
      *    @access public
      */
     function &createInvoker(&$invoker){
-        $eclinvoker = &new EclipseInvoker($invoker, $this->listener);
+        $eclinvoker = new EclipseInvoker($invoker, $this->listener);
         return $eclinvoker;
     }
 

--- a/lib/simpletest/mock_objects.php
+++ b/lib/simpletest/mock_objects.php
@@ -651,7 +651,7 @@ class SimpleMock {
      *    Creates an empty action list and expectation list.
      *    All call counts are set to zero.
      */
-    function SimpleMock() {
+    function __construct() {
         $this->actions = new SimpleCallSchedule();
         $this->expectations = new SimpleCallSchedule();
         $this->call_counts = array();

--- a/lib/simpletest/reflection_php4.php
+++ b/lib/simpletest/reflection_php4.php
@@ -20,7 +20,7 @@ class SimpleReflection {
      *    @param string $interface    Class or interface
      *                                to inspect.
      */
-    function SimpleReflection($interface) {
+    function __construct($interface) {
         $this->_interface = $interface;
     }
 

--- a/lib/simpletest/test/all_tests.php
+++ b/lib/simpletest/test/all_tests.php
@@ -2,7 +2,7 @@
 require_once(dirname(__FILE__) . '/../autorun.php');
 
 class AllTests extends TestSuite {
-    function AllTests() {
+    function __construct() {
         $this->TestSuite('All tests for SimpleTest ' . SimpleTest::getVersion());
         $this->addFile(dirname(__FILE__) . '/unit_tests.php');
         $this->addFile(dirname(__FILE__) . '/shell_test.php');

--- a/lib/simpletest/test/bad_test_suite.php
+++ b/lib/simpletest/test/bad_test_suite.php
@@ -2,7 +2,7 @@
 require_once(dirname(__FILE__) . '/../autorun.php');
 
 class BadTestCases extends TestSuite {
-    function BadTestCases() {
+    function __construct() {
         $this->TestSuite('Two bad test cases');
         $this->addFile(dirname(__FILE__) . '/support/empty_test_file.php');
     }

--- a/lib/simpletest/test/eclipse_test.php
+++ b/lib/simpletest/test/eclipse_test.php
@@ -12,7 +12,7 @@ Mock::generate('SimpleSocket');
 class TestOfEclipse extends UnitTestCase {
 	
 	function testPass() {
-		$listener = &new MockSimpleSocket();
+		$listener = new MockSimpleSocket();
 		
 		$fullpath = realpath(dirname(__FILE__).'/support/test1.php');
 		$testpath = EclipseReporter::escapeVal($fullpath);
@@ -23,7 +23,7 @@ class TestOfEclipse extends UnitTestCase {
 		
 		$pathparts = pathinfo($fullpath);
 		$filename = $pathparts['basename'];
-		$test= &new TestSuite($filename);
+		$test= new TestSuite($filename);
 		$test->addTestFile($fullpath);
 		$test->run(new EclipseReporter($listener));
 		$this->assertEqual($expected,$listener->output);

--- a/lib/simpletest/test/expectation_test.php
+++ b/lib/simpletest/test/expectation_test.php
@@ -80,7 +80,7 @@ class TestOfInequality extends UnitTestCase {
 class RecursiveNasty {
     private $me;
 
-    function RecursiveNasty() {
+    function __construct() {
         $this->me = $this;
     }
 }

--- a/lib/simpletest/test/mock_objects_test.php
+++ b/lib/simpletest/test/mock_objects_test.php
@@ -196,7 +196,7 @@ class TestOfCallSchedule extends UnitTestCase {
 }
 
 class Dummy {
-    function Dummy() {
+    function __construct() {
     }
 
     function aMethod() {
@@ -839,7 +839,7 @@ class TestOfPartialMocks extends UnitTestCase {
 }
 
 class ConstructorSuperClass {
-    function ConstructorSuperClass() { }
+    function __construct() { }
 }
 
 class ConstructorSubClass extends ConstructorSuperClass { }

--- a/lib/simpletest/test/parse_error_test.php
+++ b/lib/simpletest/test/parse_error_test.php
@@ -3,7 +3,7 @@
 require_once('../unit_tester.php');
 require_once('../reporter.php');
 
-$test = &new TestSuite('This should fail');
+$test = new TestSuite('This should fail');
 $test->addFile('test_with_parse_error.php');
 $test->run(new HtmlReporter());
 ?>

--- a/lib/simpletest/test/unit_tests.php
+++ b/lib/simpletest/test/unit_tests.php
@@ -8,7 +8,7 @@ require_once(dirname(__FILE__) . '/../web_tester.php');
 require_once(dirname(__FILE__) . '/../extensions/pear_test_case.php');
 
 class UnitTests extends TestSuite {
-    function UnitTests() {
+    function __construct() {
         $this->TestSuite('Unit tests');
         $path = dirname(__FILE__);
         $this->addFile($path . '/errors_test.php');

--- a/lib/simpletest/test/visual_test.php
+++ b/lib/simpletest/test/visual_test.php
@@ -40,7 +40,7 @@ class PassingUnitTestCaseOutput extends UnitTestCase {
     }
 
     function testExpectation() {
-        $expectation = &new EqualExpectation(25, 'My expectation message: %s');
+        $expectation = new EqualExpectation(25, 'My expectation message: %s');
         $this->assert($expectation, 25, 'My assert message : %s');
     }
 
@@ -157,7 +157,7 @@ class FailingUnitTestCaseOutput extends UnitTestCase {
     }
 
     function testExpectation() {
-        $expectation = &new EqualExpectation(25, 'My expectation message: %s');
+        $expectation = new EqualExpectation(25, 'My expectation message: %s');
         $this->assert($expectation, 24, 'My assert message : %s');        // Fail.
     }
 
@@ -272,70 +272,70 @@ Mock::generate('Dummy');
 class TestOfMockObjectsOutput extends UnitTestCase {
 
     function testCallCounts() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expectCallCount('a', 1, 'My message: %s');
         $dummy->a();
         $dummy->a();
     }
 
     function testMinimumCallCounts() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expectMinimumCallCount('a', 2, 'My message: %s');
         $dummy->a();
         $dummy->a();
     }
 
     function testEmptyMatching() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array());
         $dummy->a();
         $dummy->a(null);        // Fail.
     }
 
     function testEmptyMatchingWithCustomMessage() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array(), 'My expectation message: %s');
         $dummy->a();
         $dummy->a(null);        // Fail.
     }
 
     function testNullMatching() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array(null));
         $dummy->a(null);
         $dummy->a();        // Fail.
     }
 
     function testBooleanMatching() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array(true, false));
         $dummy->a(true, false);
         $dummy->a(true, true);        // Fail.
     }
 
     function testIntegerMatching() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array(32, 33));
         $dummy->a(32, 33);
         $dummy->a(32, 34);        // Fail.
     }
 
     function testFloatMatching() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array(3.2, 3.3));
         $dummy->a(3.2, 3.3);
         $dummy->a(3.2, 3.4);        // Fail.
     }
 
     function testStringMatching() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array('32', '33'));
         $dummy->a('32', '33');
         $dummy->a('32', '34');        // Fail.
     }
 
     function testEmptyMatchingWithCustomExpectationMessage() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect(
                 'a',
                 array(new EqualExpectation('A', 'My part expectation message: %s')),
@@ -345,7 +345,7 @@ class TestOfMockObjectsOutput extends UnitTestCase {
     }
 
     function testArrayMatching() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array(array(32), array(33)));
         $dummy->a(array(32), array(33));
         $dummy->a(array(32), array('33'));        // Fail.
@@ -356,14 +356,14 @@ class TestOfMockObjectsOutput extends UnitTestCase {
         $a->a = 'a';
         $b = new Dummy();
         $b->b = 'b';
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array($a, $b));
         $dummy->a($a, $b);
         $dummy->a($a, $a);        // Fail.
     }
 
     function testBigList() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array(false, 0, 1, 1.0));
         $dummy->a(false, 0, 1, 1.0);
         $dummy->a(true, false, 2, 2.0);        // Fail.
@@ -378,7 +378,7 @@ class TestOfPastBugs extends UnitTestCase {
     }
 
     function testMockWildcards() {
-        $dummy = &new MockDummy();
+        $dummy = new MockDummy();
         $dummy->expect('a', array('*', array(33)));
         $dummy->a(array(32), array(33));
         $dummy->a(array(32), array('33'));        // Fail.
@@ -470,7 +470,7 @@ class TestThatShouldNotBeSkipped extends UnitTestCase {
     }
 }
 
-$test = &new TestSuite('Visual test with 46 passes, 47 fails and 0 exceptions');
+$test = new TestSuite('Visual test with 46 passes, 47 fails and 0 exceptions');
 $test->add(new PassingUnitTestCaseOutput());
 $test->add(new FailingUnitTestCaseOutput());
 $test->add(new TestOfMockObjectsOutput());

--- a/lib/simpletest/test/visual_test.php
+++ b/lib/simpletest/test/visual_test.php
@@ -20,7 +20,7 @@ require_once('../xml.php');
 class TestDisplayClass {
     private $a;
 
-    function TestDisplayClass($a) {
+    function __construct($a) {
         $this->a = $a;
     }
 }
@@ -261,7 +261,7 @@ class FailingUnitTestCaseOutput extends UnitTestCase {
 }
 
 class Dummy {
-    function Dummy() {
+    function __construct() {
     }
 
     function a() {

--- a/lib/simpletest/test_case.php
+++ b/lib/simpletest/test_case.php
@@ -484,7 +484,7 @@ class TestSuite {
      *                            of the test.
      *    @access public
      */
-    function TestSuite($label = false) {
+    function __construct($label = false) {
         $this->label = $label;
         $this->test_cases = array();
     }
@@ -619,7 +619,7 @@ class BadTestSuite {
      *                            of the test.
      *    @access public
      */
-    function BadTestSuite($label, $error) {
+    function __construct($label, $error) {
         $this->label = $label;
         $this->error = $error;
     }

--- a/lib/simpletest/xml.php
+++ b/lib/simpletest/xml.php
@@ -299,7 +299,7 @@ class NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingXmlTag($attributes) {
+    function __construct($attributes) {
         $this->name = false;
         $this->attributes = $attributes;
     }
@@ -347,7 +347,7 @@ class NestingMethodTag extends NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingMethodTag($attributes) {
+    function __construct($attributes) {
         $this->NestingXmlTag($attributes);
     }
 
@@ -387,7 +387,7 @@ class NestingCaseTag extends NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingCaseTag($attributes) {
+    function __construct($attributes) {
         $this->NestingXmlTag($attributes);
     }
 
@@ -427,7 +427,7 @@ class NestingGroupTag extends NestingXmlTag {
      *    @param hash $attributes   Name value pairs.
      *    @access public
      */
-    function NestingGroupTag($attributes) {
+    function __construct($attributes) {
         $this->NestingXmlTag($attributes);
     }
 
@@ -485,7 +485,7 @@ class SimpleTestXmlParser {
      *    @param SimpleReporter $listener   Listener of tag events.
      *    @access public
      */
-    function SimpleTestXmlParser(&$listener) {
+    function __construct(&$listener) {
         $this->listener = &$listener;
         $this->expat = &$this->createParser();
         $this->tag_stack = array();

--- a/lib/sphinx/sphinxapi.php
+++ b/lib/sphinx/sphinxapi.php
@@ -85,7 +85,7 @@ class SphinxClient
 	/////////////////////////////////////////////////////////////////////////////
 
 	/// create a new client object and fill defaults
-	function SphinxClient ()
+	function __construct ()
 	{
 		$this->_host		= "localhost";
 		$this->_port		= 3312;

--- a/modules/settings/SettingsUI.php
+++ b/modules/settings/SettingsUI.php
@@ -2965,7 +2965,7 @@ class SettingsUI extends UserInterface
         $users = new Users($this->_siteID);
 
         /* If adding an e-mail username, verify it is a valid e-mail. */
-        if (strpos($loginName, '@') !== false && filter_var($username, FILTER_VALIDATE_EMAIL) === false)
+        if (strpos($loginName, '@') !== false && filter_var($loginName, FILTER_VALIDATE_EMAIL) === false)
         {
             echo 'That is not a valid login name.';
             return;

--- a/modules/settings/SettingsUI.php
+++ b/modules/settings/SettingsUI.php
@@ -1126,7 +1126,7 @@ class SettingsUI extends UserInterface
         }
 
         /* If adding an e-mail username, verify it is a valid e-mail. */
-        if (strpos($username, '@') !== false && !eregi("^[_a-z0-9-]+(.[_a-z0-9-]+)*@[a-z0-9-]+(.[a-z0-9-]+)*(.[a-z]{2,4})$", $username))
+        if (strpos($username, '@') !== false && filter_var($username, FILTER_VALIDATE_EMAIL) === false)
         {
             CommonErrors::fatal(COMMONERROR_BADFIELDS, $this, 'Username is in improper format for an E-Mail address.');
         }
@@ -1333,7 +1333,7 @@ class SettingsUI extends UserInterface
 
         /* If adding an e-mail username, verify it is a valid e-mail. */
         // FIXME: PREG!
-        if (strpos($username, '@') !== false && !eregi("^[_a-z0-9-]+(.[_a-z0-9-]+)*@[a-z0-9-]+(.[a-z0-9-]+)*(.[a-z]{2,4})$", $username))
+        if (strpos($username, '@') !== false && filter_var($username, FILTER_VALIDATE_EMAIL) === false)
         {
             CommonErrors::fatal(COMMONERROR_BADFIELDS, $this, 'Username is in improper format for an E-Mail address.');
         }
@@ -2965,7 +2965,7 @@ class SettingsUI extends UserInterface
         $users = new Users($this->_siteID);
 
         /* If adding an e-mail username, verify it is a valid e-mail. */
-        if (strpos($loginName, '@') !== false && !eregi("^[_a-z0-9-]+(.[_a-z0-9-]+)*@[a-z0-9-]+(.[a-z0-9-]+)*(.[a-z]{2,4})$", $loginName))
+        if (strpos($loginName, '@') !== false && filter_var($username, FILTER_VALIDATE_EMAIL) === false)
         {
             echo 'That is not a valid login name.';
             return;

--- a/modules/tests/waitForDb.php
+++ b/modules/tests/waitForDb.php
@@ -11,7 +11,7 @@ while (!$canConnectAndSelectDb && $count > 0)
     );
     if ($connection)
     {
-        $isDBSelected = @mysqli_select_db(DATABASE_NAME, $connection);
+        $isDBSelected = @mysqli_select_db($connection, DATABASE_NAME);
         if ($isDBSelected)
         {
             $canConnectAndSelectDb = true;

--- a/rebuild_old_docs.php
+++ b/rebuild_old_docs.php
@@ -54,7 +54,7 @@ function rebuild_old_docs() {
 $con = mysqli_connect(DATABASE_HOST, DATABASE_USER, DATABASE_PASS);
 if (!$con)
 {
-  die('Could not connect: ' . mysqli_error($co$conn));
+  die('Could not connect: ' . mysqli_error($con));
 }
 mysqli_select_db(DATABASE_NAME, $con);
 

--- a/rebuild_old_docs.php
+++ b/rebuild_old_docs.php
@@ -56,7 +56,7 @@ if (!$con)
 {
   die('Could not connect: ' . mysqli_error($con));
 }
-mysqli_select_db(DATABASE_NAME, $con);
+mysqli_select_db($con, DATABASE_NAME);
 
 rebuild_old_docs();
 ?>


### PR DESCRIPTION
Following up on #358 I think this covers most issues or at least everything php7cc finds. Includes:

* Replacing mysql with mysqli. Lifted directly from existing work in #171. Seems to work fine.
* Removing `&` from `$var &= new Foo()` instances. The assign by reference there is a syntax error in PHP7.
* Using `explode` in place of `split`.
* Replacing `ereg` functions. For instances that were validating email addresses I used `filter_var` instead. Other instances are changed to use `preg` functions.
* Get rid of `set_magic_quotes_runtime`. I conditionally disabled these calls based on PHP version although deleting them outright would probably be fine too. PHP versions that support magic quotes are all end-of-life'd already.

With this set of changes I have OpenCATS running on PHP 7.0.30
