### PR TITLE
fix LDAP module

### DIFF
--- a/config.php
+++ b/config.php
@@ -272,7 +272,7 @@ define ('LDAP_BASEDN', 'dc=example,dc=com');
 define ('LDAP_BIND_DN', 'cn=read-only-admin,dc=example,dc=com');
 define ('LDAP_BIND_PASSWORD', 'password');
 
-define ('LDAP_ACCOUNT', '{$username}'); // '{$username}' cannot be changed, else can
+define ('LDAP_ACCOUNT', 'cn={$username},dc=example,dc=com'); // '{$username}' cannot be changed, else can
 
 define ('LDAP_ATTRIBUTE_UID', 'uid');
 define ('LDAP_ATTRIBUTE_DN', 'dn');
@@ -281,6 +281,7 @@ define ('LDAP_ATTRIBUTE_FIRSTNAME', 'givenname');
 define ('LDAP_ATTRIBUTE_EMAIL', 'mail');
 
 define ('LDAP_SITEID', 1);
+define ('LDAP_AD', false); // use for AD and Samba LDAP servers
 
 
 /* Job Types mapping


### PR DESCRIPTION
I got this working properly with both Samba (AD) and OpenLDAP. LDAP and LDAPS.  
Issues preventing it from functioning:  
1. `LDAP_OPT_REFERRALS` may be required for samba or AD. Added an option to config.php to set this if desired.  
2. The second `ldap_bind` in the __authenticate__ function (after the user is found by the LDAP_BIND_DN user) uses `$result[0][LDAP_ATTRIBUTE_DN][0]` as the binding DN. This gets the first character of the `LDAP_ATTRIBUTE_DN` attribute of the first result of the query and not the desired attribute. I removed the [0] to resolve the DN correctly.  

Cosmetic fixes:  
1. Removed mix of tabs and spaces.   
2. Added some error logging.  
3. Added a clearer example of how the `LDAP_ACCOUNT` config setting is supposed to be used.  