### PR TITLE
Resolved issue #444 - rss is not valid

### DIFF
--- a/lib/DateUtility.php
+++ b/lib/DateUtility.php
@@ -347,7 +347,7 @@ class DateUtility
      * @param integer UNIX time (optional)
      * @return string RSS format date
      */
-    public function getRSSDate($unixTime = false)
+    static public function getRSSDate($unixTime = false)
     {
         if ($unixTime === false)
         {


### PR DESCRIPTION
- Further analyzing the project source code for the use of getRSSDate(), it is confirmed that the call should be made statically, as CATSUtility::getAbsoluteURI() is done.
- To resolve the issue we needed to correct the function’s signature declaration in OpenCATS/lib/DateUtility.php, as such:
- Added the “static” property at the beginning of the function signature line 350, as such:
- static public function getRSSDate($unixTime = false)