### PR TITLE
Two (2) Fixes - Resolved issue #444 + A missing class reference

### DIFF
--- a/lib/DateUtility.php
+++ b/lib/DateUtility.php
@@ -347,7 +347,7 @@ class DateUtility
      * @param integer UNIX time (optional)
      * @return string RSS format date
      */
-    public function getRSSDate($unixTime = false)
+    static public function getRSSDate($unixTime = false)
     {
         if ($unixTime === false)
         {

--- a/lib/Search.php
+++ b/lib/Search.php
@@ -32,6 +32,7 @@
 
 include_once(LEGACY_ROOT . '/lib/Pager.php');
 include_once(LEGACY_ROOT . '/lib/DatabaseSearch.php');
+include_once(LEGACY_ROOT . '/lib/JobOrderStatuses.php');
 
 if (ENABLE_SPHINX)
 {


### PR DESCRIPTION
- Resolved issue #444 - rss is not valid.
- Resolve issue with missing class reference to JobOrderStatuses which is used on line 1028 of Search.php as JobOrderStatuses::getOpenStatusSQL().