### PR TITLE
Remove references to get_magic_quotes_* functions.

### DIFF
--- a/QueueCLI.php
+++ b/QueueCLI.php
@@ -55,20 +55,6 @@ include_once(LEGACY_ROOT . '/modules/queue/constants.php');
 @session_name(CATS_SESSION_NAME);
 session_start();
 
-/* Make sure we aren't getting screwed over by magic quotes. */
-if (get_magic_quotes_runtime())
-{
-    if (function_exists('set_magic_quotes_runtime')) {
-        set_magic_quotes_runtime(0);
-    }
-}
-if (get_magic_quotes_gpc())
-{
-    $_GET     = array_map('stripslashes', $_GET);
-    $_POST    = array_map('stripslashes', $_POST);
-    $_REQUEST = array_map('stripslashes', $_REQUEST);
-}
-
 if (!isset($_SESSION['CATS']) || empty($_SESSION['CATS']))
 {
     $_SESSION['CATS'] = new CATSSession();

--- a/ajax.php
+++ b/ajax.php
@@ -46,20 +46,6 @@ include_once(LEGACY_ROOT . '/lib/CATSUtility.php');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 
-/* Make sure we aren't getting screwed over by magic quotes. */
-if (get_magic_quotes_runtime())
-{
-    if (function_exists('set_magic_quotes_runtime')) {
-        set_magic_quotes_runtime(0);
-    }
-}
-if (get_magic_quotes_gpc())
-{
-    $_GET     = array_map('stripslashes', $_GET);
-    $_POST    = array_map('stripslashes', $_POST);
-    $_REQUEST = array_map('stripslashes', $_REQUEST);
-}
-
 if (!isset($_REQUEST['f']) || empty($_REQUEST['f']))
 {
     header('Content-type: text/xml');

--- a/index.php
+++ b/index.php
@@ -78,36 +78,6 @@ session_start();
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 
-// This function assures to strip the values from
-// request arrays even if as values are arrays not only values
-function stripslashes_deep($value)
-{
-    $value = is_array($value) ?
-                array_map('stripslashes_deep', $value) :
-                stripslashes($value);
-
-    return $value;
-}
-
-/* Make sure we aren't getting screwed over by magic quotes. */
-if (get_magic_quotes_runtime())
-{
-    if (function_exists('set_magic_quotes_runtime')) {
-        set_magic_quotes_runtime(0);
-    }
-}
-if (get_magic_quotes_gpc())
-{
-    include_once(LEGACY_ROOT . '/lib/ArrayUtility.php');
-
-    $_GET     = array_map('stripslashes_deep', $_GET);
-    $_POST    = array_map('stripslashes_deep', $_POST);
-    $_REQUEST = array_map('stripslashes_deep', $_REQUEST);
-    $_GET     = ArrayUtility::arrayMapKeys('stripslashes_deep', $_GET);
-    $_POST    = ArrayUtility::arrayMapKeys('stripslashes_deep', $_POST);
-    $_REQUEST = ArrayUtility::arrayMapKeys('stripslashes_deep', $_REQUEST);
-}
-
 /* Objects can't be stored in the session if session.auto_start is enabled. */
 if (ini_get('session.auto_start') !== '0' &&
     ini_get('session.auto_start') !== 'Off')

--- a/lib/Attachments.php
+++ b/lib/Attachments.php
@@ -938,15 +938,6 @@ class AttachmentCreator
         $fileSize         = $_FILES[$fileField]['size'];
         $uploadError      = $_FILES[$fileField]['error'];
 
-        /* Recover from magic quotes. Note that tmp_name doesn't appear to
-         * get escaped, and stripslashes() on it breaks on Windows. - Will
-         */
-        if (get_magic_quotes_gpc())
-        {
-            $originalFilename = stripslashes($originalFilename);
-            $contentType      = stripslashes($contentType);
-        }
-
         /* Did a file upload error occur? */
         if ($uploadError != UPLOAD_ERR_OK)
         {

--- a/lib/InstallationTests.php
+++ b/lib/InstallationTests.php
@@ -50,7 +50,6 @@ class InstallationTests
 
         $proceed = $proceed && self::printCATSVersion();
         $proceed = $proceed && self::checkPHPVersion();
-        $proceed = $proceed && self::checkMagicQuotes();
         $proceed = $proceed && self::checkRegisterGlobals();
         $proceed = $proceed && self::checkSessionAutoStart();
         $proceed = $proceed && self::checkMySQLExtension();
@@ -75,11 +74,6 @@ class InstallationTests
         }
 
         if (!InstallationTests::checkPHPVersion())
-        {
-            $result = false;
-        }
-
-        if (!InstallationTests::checkMagicQuotes())
         {
             $result = false;
         }
@@ -176,20 +170,6 @@ class InstallationTests
             . 'Found version: %s.</td></tr>',
             PHP_VERSION
         );
-        return false;
-    }
-
-    /* magic_quotes_runtime cannot be enabled. */
-    public static function checkMagicQuotes()
-    {
-        if (!self::DEBUG_FAIL && !get_magic_quotes_runtime())
-        {
-            echo '<tr class="pass"><td>PHP.ini: magic_quotes_runtime is disabled.</td></tr>';
-            return true;
-        }
-
-        echo '<tr class="fail"><td><strong>PHP.ini: magic_quotes_runtime must be set to Off in php.ini.</strong><br />'
-            . 'Check your settings in php.ini.</td></tr>';
         return false;
     }
 

--- a/modules/import/ImportUI.php
+++ b/modules/import/ImportUI.php
@@ -487,15 +487,6 @@ class ImportUI extends UserInterface
         $fileSize         = $_FILES['file']['size'];
         $fileUploadError  = $_FILES['file']['error'];
 
-        /* Recover from magic quotes. Note that tmp_name doesn't appear to
-         * get escaped, and stripslashes() on it breaks on Windows. - Will
-         */
-        if (get_magic_quotes_gpc())
-        {
-            $originalFilename = stripslashes($originalFilename);
-            $contentType      = stripslashes($contentType);
-        }
-
         if ($fileUploadError != UPLOAD_ERR_OK)
         {
             $this->_template->assign(


### PR DESCRIPTION
Since PHP 5.4.0, released on 2012-01-03 (according to https://www.php.net/releases/#5.4.0) the get_magic_quotes_* functions allways return false. These functions were deprecated on PHP 7.4.0  (released on 2019-11-28, check https://www.php.net/releases/#7.4.0) and, as such, they emit a E_DEPRECATED warning every time they're used.
So, accordingly, I've created this PR to remove the use of these functions throughout the code. It also removes the checks from the InstallationTests.php and the stripslashes_deep function from the index.php files.

If this PR is wrongly created in any way, please let me know so I can improve it.