### PR TITLE
Update careers/index.php

### DIFF
--- a/careers/index.php
+++ b/careers/index.php
@@ -34,6 +34,7 @@
 $careerPage = true;
 
 chdir('..');
+include_once('config.php') ;
 include_once(LEGACY_ROOT . '/lib/CATSUtility.php');
 include_once(CATSUtility::getIndexName());
 


### PR DESCRIPTION
The LEGACY_ROOT constant is defined in config.php but this file is not included in the careers/index.php so, there's an error, resulting on a blank page showed to the user.
The inclusion of config.php in this file solves this problem
