### PR TITLE
Fix a syntax error in the Mailer.php file

### DIFF
--- a/lib/Mailer.php
+++ b/lib/Mailer.php
@@ -208,7 +208,7 @@ class Mailer
 
             if ($signature)
             {
-                $body .= '\n<br />\n<br /><span style=\"font-size: 10pt;\">Powered by <a href=\"http://www.opencats.org" alt=\"OpenCATS "
+                $body .= '\n<br />\n<br /><span style=\"font-size: 10pt;\">Powered by <a href=\"http://www.opencats.org\" alt=\"OpenCATS "
                     . "Applicant Tracking System\">OpenCATS</a> (Free ATS)</span>';
             }
 


### PR DESCRIPTION
I've fixed an apparent syntax error in the `Mailer.php` file that is causing the system to fail to load when the SMTP mailing option is selected.