### PR TITLE
Fixed critical upload vulnerability

### DIFF
--- a/lib/FileUtility.php
+++ b/lib/FileUtility.php
@@ -184,11 +184,17 @@ class FileUtility
 
         /* Is the file extension safe? */
         $fileExtension = self::getFileExtension($filename);
-        if (in_array($fileExtension, $GLOBALS['badFileExtensions']))
+        
+        /* Use a whitelist instead of a blacklist to prevent possible bypasses */
+        if (!preg_match("/(?i)\.(pdf|docx?|rtf|odt?g?|txt|wpd|jpe?g|png|csv|xlsx?|ppt|msg|heic|tiff?|html?|bmp|wps|xps)$/i", $fileExtension))
+        {
+            $filename .= ".txt";
+        }
+/*        if (in_array($fileExtension, $GLOBALS['badFileExtensions']))
         {
             $filename .= '.txt';
         }
-
+*/
         return $filename;
     }
 
@@ -563,7 +569,7 @@ class FileUtility
             if (!eval(Hooks::get('FILE_UTILITY_SPACE_CHECK'))) return;
 
             $uploadPath = FileUtility::getUploadPath($siteID, $subDirectory);
-            $newFileName = $_FILES[$id]['name'];
+            $newFileName = FileUtility::makeSafeFilename($_FILES[$id]['name']);
 
             // Could just while(file_exists) it, but I'm paranoid of infinate loops
             // Shouldn't have 1000 files of the same name anyway


### PR DESCRIPTION
There is a **critical vulnerability** that allows **remote code execution** due to lack of proper validation of the uploaded file.

This affects all versions of OpenCATS I could test. (Editing .htaccess does not fix the issue in non-Apache webservers)

Just to show how critical this is, I wrote a simple script to exploit this vulnerability.

I did not publish this script yet, but I will do so within 90 days from today or right after this issue has been fixed (either via this pull request or otherwise).

The result against both Linux and Windows webservers was this:

![image](https://user-images.githubusercontent.com/3837916/134617049-9e203e8c-6834-42e5-bdd6-8eb0eb0a8b51.png)

![image](https://user-images.githubusercontent.com/3837916/134616895-edd91edb-84e8-46b9-90c7-e813da80d694.png)
