### PR TITLE
Pin MariaDB to 10.6 for travis-ci integration tests.

### DIFF
--- a/lib/FileUtility.php
+++ b/lib/FileUtility.php
@@ -184,11 +184,17 @@ class FileUtility
 
         /* Is the file extension safe? */
         $fileExtension = self::getFileExtension($filename);
-        if (in_array($fileExtension, $GLOBALS['badFileExtensions']))
+        
+        /* Use a whitelist instead of a blacklist to prevent possible bypasses */
+        if (!preg_match("/(?i)\.(pdf|docx?|rtf|odt?g?|txt|wpd|jpe?g|png|csv|xlsx?|ppt|msg|heic|tiff?|html?|bmp|wps|xps)$/i", $fileExtension))
+        {
+            $filename .= ".txt";
+        }
+/*        if (in_array($fileExtension, $GLOBALS['badFileExtensions']))
         {
             $filename .= '.txt';
         }
-
+*/
         return $filename;
     }
 
@@ -563,7 +569,7 @@ class FileUtility
             if (!eval(Hooks::get('FILE_UTILITY_SPACE_CHECK'))) return;
 
             $uploadPath = FileUtility::getUploadPath($siteID, $subDirectory);
-            $newFileName = $_FILES[$id]['name'];
+            $newFileName = FileUtility::makeSafeFilename($_FILES[$id]['name']);
 
             // Could just while(file_exists) it, but I'm paranoid of infinate loops
             // Shouldn't have 1000 files of the same name anyway


### PR DESCRIPTION
MariaDB 10.7 (latest) [fails to start a database if it uses non-zlib compression. ](https://mariadb.com/kb/en/upgrading-from-mariadb-106-to-mariadb-107/) and https://mariadb.com/kb/en/compression-plugins/#upgrading 

Pinning MariaDB to 10.6.