### PR TITLE
updated mariadb version

### DIFF
--- a/docker/docker-compose-test.yml
+++ b/docker/docker-compose-test.yml
@@ -26,7 +26,7 @@ services:
 
     opencatsdb:
       container_name: opencats_test_mariadb
-      image: mariadb:10.6
+      image: mariadb:10.10
       ports:
         - 3306
       environment:


### PR DESCRIPTION
Tests do not complete with MariaDB 10.6 as there's an innodb rollback created with 10.10. Therefore moving to MariaDB10.10