### PR TITLE
Use mb_substr() for correct abbreviation of non-ASCII characters

### DIFF
--- a/lib/Candidates.php
+++ b/lib/Candidates.php
@@ -2066,7 +2066,7 @@ class CandidatesDataGrid extends DataGrid
                                      'filter'         => 'candidate.web_site'),
 
             'Key Skills' =>    array('select'  => 'candidate.key_skills AS keySkills',
-                                     'pagerRender' => 'return substr(trim($rsData[\'keySkills\']), 0, 30) . (strlen(trim($rsData[\'keySkills\'])) > 30 ? \'...\' : \'\');',
+                                     'pagerRender' => 'return mb_substr(trim($rsData[\'keySkills\']), 0, 30) . (strlen(trim($rsData[\'keySkills\'])) > 30 ? \'...\' : \'\');',
                                      'sortableColumn'    => 'keySkills',
                                      'pagerWidth'   => 210,
                                      'filter'         => 'candidate.key_skills'),

--- a/lib/StringUtility.php
+++ b/lib/StringUtility.php
@@ -499,24 +499,24 @@ class StringUtility
 
         if ($lastCommaFirst)
         {
-            $firstInitial = $firstName[0] . '.';
+            $firstInitial = mb_substr($firstName, 0, 1) . '.';
 
             if (strlen($lastName) > $maxLength)
             {
                 return ucwords(
-                    substr($lastName, 0, $maxLength) . ', ' . $firstInitial
+                    mb_substr($lastName, 0, $maxLength) . ', ' . $firstInitial
                 );
             }
 
             return ucwords($lastName . ', ' . $firstInitial);
         }
 
-        $lastInitial = $lastName[0] . '.';
+        $lastInitial = mb_substr($lastName, 0, 1) . '.';
 
         if (strlen($firstName) > $maxLength)
         {
             return ucwords(
-                substr($firstName, 0, $maxLength) . ' ' . $lastInitial
+                mb_substr($firstName, 0, $maxLength) . ' ' . $lastInitial
             );
         }
 


### PR DESCRIPTION
When using substr() or another method to reduce a string to/by 1 byte, many UTF-8 characters are lost (displayed as � ). Switching to mb_substr() fixes this.
