### PR TITLE
joborders: for forms, take a default company name from the database

### DIFF
--- a/modules/companies/CompaniesUI.php
+++ b/modules/companies/CompaniesUI.php
@@ -888,7 +888,7 @@ class CompaniesUI extends UserInterface
 
         if ($rs['defaultCompany'] == 1)
         {
-            $this->listByView('Cannot delete internal postings company.');
+            $this->listByView('Cannot delete default company.');
             return;
         }
 

--- a/modules/joborders/Add.tpl
+++ b/modules/joborders/Add.tpl
@@ -67,7 +67,7 @@
                                 <div id="CompanyResults" class="ajaxSearchResults"></div>
 
                                 <?php if ($this->defaultCompanyID !== false): ?>
-                                    <input type="radio" name="typeCompany" id="defaultCompany" onchange="if(document.getElementById('companyName').disabled == false && document.getElementById('companyID').value > 0) {oldCompanyID = document.getElementById('companyID').value; } else if(document.getElementById('companyName').disabled == false) { oldCompanyID = 0; } document.getElementById('companyName').disabled = true; document.getElementById('companyID').value = '<?php echo($this->defaultCompanyID); ?>'; ">&nbsp;Internal Posting<br />
+                                    <input type="radio" name="typeCompany" id="defaultCompany" onchange="if(document.getElementById('companyName').disabled == false && document.getElementById('companyID').value > 0) {oldCompanyID = document.getElementById('companyID').value; } else if(document.getElementById('companyName').disabled == false) { oldCompanyID = 0; } document.getElementById('companyName').disabled = true; document.getElementById('companyID').value = '<?php echo($this->defaultCompanyID); ?>'; ">&nbsp;<?php echo($this->defaultCompanyRS['name']); ?><br />
                                 <?php endif; ?>
 
                                 <script type="text/javascript">oldCompanyID = -1; watchCompanyIDChangeJO('<?php echo($this->sessionCookie); ?>');</script>

--- a/modules/joborders/Edit.tpl
+++ b/modules/joborders/Edit.tpl
@@ -75,7 +75,7 @@
                          </td>
                          <td class="tdData">
                             <?php if ($this->defaultCompanyID !== false): ?>
-                                <input type="radio" name="typeCompany" <?php if ($this->defaultCompanyID == $this->data['companyID']) echo(' checked'); ?> id="defaultCompany" onchange="if(document.getElementById('companyName').disabled == false && document.getElementById('companyID').value > 0) {oldCompanyID = document.getElementById('companyID').value; } else if(document.getElementById('companyName').disabled == false) { oldCompanyID = 0; } document.getElementById('companyName').disabled = true; document.getElementById('companyID').value = '<?php echo($this->defaultCompanyID); ?>'; ">&nbsp;Internal Posting
+                                <input type="radio" name="typeCompany" <?php if ($this->defaultCompanyID == $this->data['companyID']) echo(' checked'); ?> id="defaultCompany" onchange="if(document.getElementById('companyName').disabled == false && document.getElementById('companyID').value > 0) {oldCompanyID = document.getElementById('companyID').value; } else if(document.getElementById('companyName').disabled == false) { oldCompanyID = 0; } document.getElementById('companyName').disabled = true; document.getElementById('companyID').value = '<?php echo($this->defaultCompanyID); ?>'; ">&nbsp;<?php echo($this->defaultCompanyRS['name']); ?>
                             <?php endif; ?>
                             <script type="text/javascript">oldCompanyID = -1; watchCompanyIDChangeJO('<?php echo($this->sessionCookie); ?>');</script>
                          </td>


### PR DESCRIPTION
Default company name is saved in the database and can be changed. However, for "Add Job Order" and "Edit Job Order" forms it was hardcoded to the standard name ("Internal Posting").

![default-company-name](https://github.com/opencats/OpenCATS/assets/44649402/29e2c2ca-29da-4260-b746-06d38a1061b7)
