### PR TITLE
Fix "Other" section overlap on company edit page

### DIFF
--- a/modules/companies/Edit.tpl
+++ b/modules/companies/Edit.tpl
@@ -21,10 +21,10 @@
 
                 <table width="100%">
                     <tr>
-                        <td valign="top" width="50%" height="285">
+                        <td valign="top" width="50%" height="100%">
                             <p class="noteUnsized">Basic Information</p>
 
-                            <table class="editTable" width="100%" height="100%">
+                            <table class="editTable" width="100%" height="285">
                                 <tr>
                                     <td class="tdVertical">
                                         <label id="nameLabel" for="name">Company Name:</label>
@@ -105,10 +105,10 @@
                             </table>
                         </td>
 
-                        <td width="50%" valign="top" height="285">
+                        <td width="50%" valign="top" height="100%">
                             <p class="noteUnsized">Contact Information</p>
 
-                            <table class="editTable" width="100%" height="100%">
+                            <table class="editTable" width="100%" height="285">
                                 <tr>
                                     <td class="tdVertical">
                                         <label id="phone1Label" for="phone1">Primary Phone:</label>


### PR DESCRIPTION
This adjusts the company edit layout so the outer `<td>` uses `height="100%"` and the inner `editTable` uses a fixed height, matching the contact edit template.

As a result, the right-hand "Contact Information" panel no longer visually overlaps the "Other" section at the bottom of the page.
