### PR TITLE
Normalize initial database state and upgrade consistency

### DIFF
--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -847,7 +847,7 @@ insert  into `module_schema`(`module_schema_id`,`name`,`version`) values (9,'ext
 insert  into `module_schema`(`module_schema_id`,`name`,`version`) values (10,'graphs',0);
 insert  into `module_schema`(`module_schema_id`,`name`,`version`) values (11,'home',0);
 insert  into `module_schema`(`module_schema_id`,`name`,`version`) values (12,'import',0);
-insert  into `module_schema`(`module_schema_id`,`name`,`version`) values (13,'install',363);
+insert  into `module_schema`(`module_schema_id`,`name`,`version`) values (13,'install',365);
 insert  into `module_schema`(`module_schema_id`,`name`,`version`) values (14,'joborders',0);
 insert  into `module_schema`(`module_schema_id`,`name`,`version`) values (15,'lists',0);
 insert  into `module_schema`(`module_schema_id`,`name`,`version`) values (16,'login',0);
@@ -991,7 +991,7 @@ CREATE TABLE `site` (
   `file_size_kb` int(11) DEFAULT '0',
   `page_views` bigint(20) DEFAULT '0',
   `page_view_days` int(11) DEFAULT '0',
-  `last_viewed_day` date DEFAULT NULL,
+  `last_viewed_day` date NOT NULL DEFAULT '1000-01-01',
   `first_time_setup` tinyint(4) DEFAULT '0',
   `localization_configured` int(1) DEFAULT '0',
   `agreed_to_license` int(1) DEFAULT '0',
@@ -1002,8 +1002,8 @@ CREATE TABLE `site` (
 
 /*Data for the table `site` */
 
-insert  into `site`(`site_id`,`name`,`is_demo`,`user_licenses`,`entered_by`,`date_created`,`unix_name`,`company_id`,`is_free`,`account_active`,`account_deleted`,`reason_disabled`,`time_zone`,`time_format_24`,`date_format_ddmmyy`,`is_hr_mode`,`file_size_kb`,`page_views`,`page_view_days`,`last_viewed_day`,`first_time_setup`,`localization_configured`,`agreed_to_license`,`limit_warning`) values (1,'testdomain.com',0,0,0,'1000-01-01 00:00:00',NULL,NULL,0,1,0,NULL,2,0,1,0,0,0,0,'2009-11-19',0,0,1,0);
-insert  into `site`(`site_id`,`name`,`is_demo`,`user_licenses`,`entered_by`,`date_created`,`unix_name`,`company_id`,`is_free`,`account_active`,`account_deleted`,`reason_disabled`,`time_zone`,`time_format_24`,`date_format_ddmmyy`,`is_hr_mode`,`file_size_kb`,`page_views`,`page_view_days`,`last_viewed_day`,`first_time_setup`,`localization_configured`,`agreed_to_license`,`limit_warning`) values (180,'CATS_ADMIN',0,0,0,'1000-01-01 00:00:00','catsadmin',NULL,0,1,0,NULL,2,0,1,0,0,0,0,NULL,0,0,0,0);
+insert  into `site`(`site_id`,`name`,`is_demo`,`user_licenses`,`entered_by`,`date_created`,`unix_name`,`company_id`,`is_free`,`account_active`,`account_deleted`,`reason_disabled`,`time_zone`,`time_format_24`,`date_format_ddmmyy`,`is_hr_mode`,`file_size_kb`,`page_views`,`page_view_days`,`last_viewed_day`,`first_time_setup`,`localization_configured`,`agreed_to_license`,`limit_warning`) values (1,'testdomain.com',0,0,0,'1000-01-01 00:00:00',NULL,NULL,0,1,0,NULL,2,0,1,0,0,0,0,'1000-01-01',0,0,1,0);
+insert  into `site`(`site_id`,`name`,`is_demo`,`user_licenses`,`entered_by`,`date_created`,`unix_name`,`company_id`,`is_free`,`account_active`,`account_deleted`,`reason_disabled`,`time_zone`,`time_format_24`,`date_format_ddmmyy`,`is_hr_mode`,`file_size_kb`,`page_views`,`page_view_days`,`last_viewed_day`,`first_time_setup`,`localization_configured`,`agreed_to_license`,`limit_warning`) values (180,'CATS_ADMIN',0,0,0,'1000-01-01 00:00:00','catsadmin',NULL,0,1,0,NULL,2,0,1,0,0,0,0,'1000-01-01',0,0,0,0);
 
 /*Table structure for table `sph_counter` */
 

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1328,6 +1328,25 @@ class CATSSchema
             '364' => '
                 UPDATE user SET password = md5(password) WHERE can_change_password=1;
             ',
+            '365' => 'PHP:
+                $col = $db->getAssoc("SHOW COLUMNS FROM `site` LIKE \'last_viewed_day\'");
+
+                if (!empty($col))
+                {
+                    $db->query(
+                        "UPDATE `site`
+                         SET `last_viewed_day` = \'1000-01-01\'
+                         WHERE `last_viewed_day` IS NULL OR `last_viewed_day` = \'0000-00-00\'",
+                        true
+                    );
+
+                    $db->query(
+                        "ALTER TABLE `site`
+                         MODIFY `last_viewed_day` DATE NOT NULL DEFAULT \'1000-01-01\'",
+                        true
+                    );
+                }
+            ',
 
         );
     }


### PR DESCRIPTION
## Summary

This pull request normalizes OpenCATS’ initial database state and removes demo-style seed records, so fresh installations start with a minimal and predictable dataset.

It removes default tag records (and their seeded candidate_tag relations), drops pre-seeded history and user_login rows so audit/login logs start empty, and lets MySQL assign primary keys from 1 upwards in the career_portal_template and email_template tables. It also removes artificially high AUTO_INCREMENT starts (e.g. candidate and mru).

In addition, it standardizes seeded timestamps and counters to deterministic neutral values (sentinel dates and zeroed counters) and makes `site.last_viewed_day` consistently non-null by using the DATE sentinel `1000-01-01`.

Changes touch:

* `db/cats_schema.sql` (new installations)
* `modules/install/Schema.php` (upgrade step to backfill and enforce `site.last_viewed_day`)

## Motivation

The previous seed data included opinionated demo content (tags, tag relations, historic audit entries and a login record) and created confusingly high AUTO_INCREMENT values on brand-new installations, making the database appear as if large ID ranges had been skipped.

Additionally, several seeded timestamps and counters contained arbitrary historic values that were not meaningful for production usage. By removing unnecessary demo records, relying on MySQL for PK assignment, and using deterministic neutral seed values (including a sentinel for `site.last_viewed_day`), new installations become easier to understand and debug.

For existing installations, a small upgrade step backfills NULL/zero-dates in `site.last_viewed_day` to the sentinel and enforces a consistent NOT NULL definition to avoid mixed states across environments.