### PR TITLE
security: do not expose database password to the client during upgrade

### DIFF
--- a/installwizard.php
+++ b/installwizard.php
@@ -123,7 +123,7 @@
                                                 </tr>
                                                 <tr>
                                                     <td nowrap="nowrap">Database Password:</td>
-                                                    <td valign="top"><input type="text" size="20" id="dbpass" value="" /></td>
+                                                    <td valign="top"><input type="password" size="20" id="dbpass" value="" /></td>
                                                 </tr>
                                                 <tr>
                                                     <td>Database Host: <span style="color: #ff0000">*</span></td>

--- a/modules/install/ajax/ui.php
+++ b/modules/install/ajax/ui.php
@@ -120,7 +120,7 @@ switch ($action)
                 CATSUtility::changeConfigSetting('DATABASE_USER', "'" . $_REQUEST['user'] . "'");
             }
 
-            if (isset($_REQUEST['pass']))
+            if (isset($_REQUEST['pass']) && $_REQUEST['pass'] !== '')
             {
                 CATSUtility::changeConfigSetting('DATABASE_PASS', "'" . $_REQUEST['pass'] . "'");
             }
@@ -146,13 +146,20 @@ switch ($action)
             die();
         }
 
+        $dbPassPlaceholder = '';
+        if (DATABASE_PASS !== '')
+        {
+            $dbPassPlaceholder = 'Leave blank to keep existing password';
+        }
+
         echo '
             <script type="text/javascript">
                 setActiveStep(2);
                 showTextBlock(\'databaseConnectivity\');
                 document.getElementById(\'dbname\').value = \'' . htmlspecialchars(DATABASE_NAME) . '\';
                 document.getElementById(\'dbuser\').value = \'' . htmlspecialchars(DATABASE_USER) . '\';
-                document.getElementById(\'dbpass\').value = \'' . htmlspecialchars(DATABASE_PASS) . '\';
+                document.getElementById(\'dbpass\').value = \'\';
+                document.getElementById(\'dbpass\').placeholder = \'' . $dbPassPlaceholder . '\';
                 document.getElementById(\'dbhost\').value = \'' . htmlspecialchars(DATABASE_HOST) . '\';
             </script>';
         break;


### PR DESCRIPTION
## Summary

The database password field in the installer is now rendered as a password input instead of a plain text field.

When loading existing database settings, the current database password is no longer written into the form via JavaScript. The field remains empty and, if a password already exists, shows a placeholder hint instead.

The database password in `config.php` is only updated when a non-empty value is provided, preventing accidental overwrites or clearing of an existing password.

## Motivation

During upgrades of existing installations, the database password was previously sent to the client and could be accessed through the HTML or JavaScript source. This unnecessarily exposed sensitive credentials on the client side.

This change ensures that the existing database password remains server-side and is reused for connectivity checks without ever being transferred to the client.