### PR TITLE
security: add baseline security headers

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,11 +5,11 @@ Options -Indexes
 # Basic security headers.
 # These defaults are intentionally conservative to avoid breaking common customizations.
 <IfModule mod_headers.c>
-    Header set X-Content-Type-Options "nosniff"
-    Header set Referrer-Policy "strict-origin-when-cross-origin"
-    Header set Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set Referrer-Policy "strict-origin-when-cross-origin"
+    Header always set Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
 
     # Prevent clickjacking on the OpenCATS UI.
     # Note: /careers/ intentionally unsets this header in careers/.htaccess to allow embedding Career Portal into external websites using an iframe.
-    Header set X-Frame-Options "SAMEORIGIN"
+    Header always set X-Frame-Options "SAMEORIGIN"
 </IfModule>

--- a/careers/.htaccess
+++ b/careers/.htaccess
@@ -1,5 +1,5 @@
 # The Career Portal might be embedded into external websites using an iframe.
 # Allow embedding by unsetting the clickjacking protection header that is set globally.
 <IfModule mod_headers.c>
-    Header unset X-Frame-Options
+    Header always unset X-Frame-Options
 </IfModule>


### PR DESCRIPTION
## Summary

This PR adds a small set of conservative, low-risk HTTP security headers to the default Apache `.htaccess` to improve baseline hardening for public OpenCATS installations.

To avoid breaking setups where the Career Portal is embedded into an external website, the clickjacking protection (`X-Frame-Options: SAMEORIGIN`) is applied globally but explicitly unset for `/careers/` (and all subpaths) via a dedicated `careers/.htaccess`.

## Motivation

OpenCATS currently ships without a baseline set of HTTP security headers. Adding these defaults provides immediate, broadly compatible security improvements for typical deployments without requiring server-specific configuration.

The chosen headers are intentionally conservative to minimize the risk of breaking existing installations or customizations, while still providing meaningful protection (e.g. against MIME sniffing, clickjacking, and unnecessary referrer leakage).