### PR TITLE
fix: preselect Email activity type in edit form

### DIFF
--- a/js/activity.js
+++ b/js/activity.js
@@ -64,7 +64,7 @@ function Activity_fillTypeSelect(selectList, selectedText)
     /* Email option. */
     optionElements[4] = document.createElement('option');
     optionElements[4].value = ACTIVITY_EMAIL;
-    optionElements[4].appendChild(document.createTextNode('E-Mail'));
+    optionElements[4].appendChild(document.createTextNode('Email'));
 
     /* Meeting option. */
     optionElements[5] = document.createElement('option');
@@ -95,7 +95,7 @@ function Activity_fillTypeSelect(selectList, selectedText)
         {
             optionElements[3].setAttribute('selected', 'selected');
         }
-        else if (selectedText == 'E-Mail')
+        else if (selectedText == 'Email')
         {
             optionElements[4].setAttribute('selected', 'selected');
         }

--- a/modules/candidates/AddActivityChangeStatusModal.tpl
+++ b/modules/candidates/AddActivityChangeStatusModal.tpl
@@ -126,7 +126,7 @@
                             <option value="<?php echo(ACTIVITY_CALL_TALKED); ?>">Call (Talked)</option>
                             <option value="<?php echo(ACTIVITY_CALL_LVM); ?>">Call (LVM)</option>
                             <option value="<?php echo(ACTIVITY_CALL_MISSED); ?>">Call (Missed)</option>
-                            <option value="<?php echo(ACTIVITY_EMAIL); ?>">E-Mail</option>
+                            <option value="<?php echo(ACTIVITY_EMAIL); ?>">Email</option>
                             <option value="<?php echo(ACTIVITY_MEETING); ?>">Meeting</option>
                             <option value="<?php echo(ACTIVITY_OTHER); ?>">Other</option>
                         </select><br />

--- a/modules/contacts/AddActivityScheduleEventModal.tpl
+++ b/modules/contacts/AddActivityScheduleEventModal.tpl
@@ -45,7 +45,7 @@
                             <option value="<?php echo(ACTIVITY_CALL_TALKED); ?>">Call (Talked)</option>
                             <option value="<?php echo(ACTIVITY_CALL_LVM); ?>">Call (LVM)</option>
                             <option value="<?php echo(ACTIVITY_CALL_MISSED); ?>">Call (Missed)</option>
-                            <option value="<?php echo(ACTIVITY_EMAIL); ?>">E-Mail</option>
+                            <option value="<?php echo(ACTIVITY_EMAIL); ?>">Email</option>
                             <option value="<?php echo(ACTIVITY_MEETING); ?>">Meeting</option>
                             <option value="<?php echo(ACTIVITY_OTHER); ?>">Other</option>
                         </select><br />
@@ -122,7 +122,7 @@
                                     
                                     <div style="display:none;" id="reminderArea">
                                         <div>
-                                            <label>E-Mail To:</label><br />
+                                            <label>Email To:</label><br />
                                             <input type="text" id="sendEmail" name="sendEmail" class="inputbox" style="width: 150px" value="<?php $this->_($this->userEmail); ?>" />
                                         </div>
                                         <div>


### PR DESCRIPTION
When editing an existing activity of type "Email", the edit form could incorrectly preselect the first option ("Call"). This happened because the activity list renders the type as "Email" (from `activity_type.short_description`), while the edit UI dropdown used the label "E-Mail", causing the preselect matching to fail.

This PR aligns the dropdown label with the stored/rendered value and updates the edit preselection logic accordingly.