### PR TITLE
fix: preserve job order regarding when editing

### DIFF
--- a/ajax/editActivity.php
+++ b/ajax/editActivity.php
@@ -69,7 +69,7 @@ $siteID = $interface->getSiteID();
 
 $activityID = $_POST['activityID'];
 $type       = $_POST['type'];
-$jobOrderID = $_POST['jobOrderID'];
+$jobOrderID = isset($_POST['jobOrderID']) ? trim($_POST['jobOrderID']) : null;
 
 /* Decode and trim the activity notes from the company. */
 $activityNote = trim(urldecode($_POST['notes']));
@@ -86,6 +86,13 @@ if (!DateUtility::validate('-', $activityDate, $dateFormatFlag))
 {
     die('Invalid availability date.');
     return;
+}
+
+if ($jobOrderID === null || $jobOrderID === '' || $jobOrderID === 'NULL' ||
+    $jobOrderID === '0' || $jobOrderID === '-1' || !is_numeric($jobOrderID) ||
+    (int) $jobOrderID <= 0)
+{
+    $jobOrderID = -1;
 }
 
 /* Convert formatted time to UNIX timestamp. */

--- a/js/activity.js
+++ b/js/activity.js
@@ -116,13 +116,20 @@ function Activity_fillTypeSelect(selectList, selectedText)
     }
 }
 
-function Activity_fillRegardingSelect(selectList, jobOrderNodes, selectedText)
+function Activity_fillRegardingSelect(selectList, jobOrderNodes, selectedText, selectedJobOrderID)
 {
+    var hasValidJobOrderID = false;
+
+    if (selectedJobOrderID && selectedJobOrderID.match(/^\d+$/) && selectedJobOrderID != '0')
+    {
+        hasValidJobOrderID = true;
+    }
+
     /* General option. */
     generalOption = document.createElement("option");
     generalOption.value = "NULL";
     generalOption.appendChild(document.createTextNode("General"));
-    if (selectedText == "General")
+    if (!hasValidJobOrderID)
     {
         generalOption.setAttribute("selected", "selected");
     }
@@ -153,8 +160,13 @@ function Activity_fillRegardingSelect(selectList, jobOrderNodes, selectedText)
 
         option.value = IDNode.firstChild.nodeValue;
         option.appendChild(document.createTextNode(optionText));
-        if (selectedText == optionText)
+        if (hasValidJobOrderID && option.value == selectedJobOrderID)
         {
+            option.setAttribute("selected", "selected");
+        }
+        else if (!hasValidJobOrderID && selectedText == optionText)
+        {
+            generalOption.removeAttribute("selected");
             option.setAttribute("selected", "selected");
         }
         selectList.appendChild(option);
@@ -236,10 +248,16 @@ function Activity_editEntry(activityID, dataItemID, dataItemType, sessionCookie)
 
         /* Create the "Regarding" select list and add options to it. */
         var regardingSelectList = document.createElement("select");
+        var selectedJobOrderID = "";
+        if (regardingTD && regardingTD.getAttribute)
+        {
+            selectedJobOrderID = regardingTD.getAttribute("data-joborder-id");
+        }
         Activity_fillRegardingSelect(
             regardingSelectList,
             http.responseXML.getElementsByTagName("joborder"),
-            regardingTD.firstChild.nodeValue
+            regardingTD.firstChild.nodeValue,
+            selectedJobOrderID
         );
         regardingSelectList.className = "inputbox";
 

--- a/lib/ActivityEntries.php
+++ b/lib/ActivityEntries.php
@@ -80,12 +80,17 @@ class ActivityEntries
      * @param flag Activity type flag.
      * @param string Activity notes.
      * @param integer Entered-by user ID.
-     * @param integer Job Order ID; -1 for general.
+     * @param integer Job Order ID; -1 for general (stored as NULL).
      * @return integer New Activity ID; -1 on failure.
      */
     public function add($dataItemID, $dataItemType, $activityType,
         $activityNotes, $enteredBy, $jobOrderID = -1)
     {
+        if (!ctype_digit((string) $jobOrderID) || (int) $jobOrderID <= 0)
+        {
+            $jobOrderID = -1;
+        }
+
         $sql = sprintf(
             "INSERT INTO activity (
                 data_item_id,
@@ -111,7 +116,7 @@ class ActivityEntries
             )",
             $this->_db->makeQueryInteger($dataItemID),
             $this->_db->makeQueryInteger($dataItemType),
-            $this->_db->makeQueryInteger($jobOrderID),
+            $this->_db->makeQueryIntegerOrNULL($jobOrderID),
             $this->_db->makeQueryInteger($enteredBy),
             $this->_db->makeQueryInteger($activityType),
             $this->_db->makeQueryString($activityNotes),
@@ -142,7 +147,8 @@ class ActivityEntries
         /* If there is a job order being associated, update it's modified
          * timestamp, too.
          */
-        if ($jobOrderID != -1)
+        if (!empty($jobOrderID) && ctype_digit((string) $jobOrderID) &&
+            (int) $jobOrderID > 0)
         {
             $this->_updateDataItemModified($jobOrderID, DATA_ITEM_JOBORDER);
         }
@@ -156,7 +162,7 @@ class ActivityEntries
      * @param integer Activity ID to update.
      * @param flag New activity type flag.
      * @param string New activity notes.
-     * @param integer New Job Order ID; -1 for general.
+     * @param integer New Job Order ID; -1 for general (stored as NULL).
      * @return boolean True if successful; false otherwise.
      */
     public function update($activityID, $activityType, $activityNotes,
@@ -203,6 +209,11 @@ class ActivityEntries
             $newJobOrderID = $jobOrderID;
         }
 
+        if (!ctype_digit((string) $newJobOrderID) || (int) $newJobOrderID <= 0)
+        {
+            $newJobOrderID = -1;
+        }
+
         $sql = sprintf(
             "UPDATE
                 activity
@@ -217,7 +228,7 @@ class ActivityEntries
                 site_id = %s",
             $this->_db->makeQueryInteger($activityType),
             $this->_db->makeQueryString($activityNotes),
-            $this->_db->makeQueryInteger($newJobOrderID),
+            $this->_db->makeQueryIntegerOrNULL($newJobOrderID),
             $this->_db->makeQueryInteger($activityID),
             $this->_siteID
         );
@@ -267,7 +278,8 @@ class ActivityEntries
         /* If there is a job order being associated, update it's modified
          * timestamp, too.
          */
-        if (!empty($jobOrderID) && ctype_digit((string) $jobOrderID))
+        if (!empty($jobOrderID) && ctype_digit((string) $jobOrderID) &&
+            (int) $jobOrderID > 0)
         {
             $this->_updateDataItemModified($jobOrderID, DATA_ITEM_JOBORDER);
         }
@@ -276,7 +288,7 @@ class ActivityEntries
          * is valid, update its modified timestamp, too.
          */
         if (!empty($newJobOrderID) && ctype_digit((string) $newJobOrderID) &&
-            $jobOrderID != $newJobOrderID)
+            (int) $newJobOrderID > 0 && $jobOrderID != $newJobOrderID)
         {
             $this->_updateDataItemModified($newJobOrderID, DATA_ITEM_JOBORDER);
         }

--- a/modules/candidates/Show.tpl
+++ b/modules/candidates/Show.tpl
@@ -639,7 +639,7 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                         <td align="left" valign="top" id="activityDate<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['dateCreated']) ?></td>
                         <td align="left" valign="top" id="activityType<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
-                        <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['regarding']) ?></td>
+                        <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>" data-joborder-id="<?php echo(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
                         <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br($activityData['notes'])); ?></td>
 <?php if (!$this->isPopup): ?>
                         <td align="center" >

--- a/modules/companies/Show.tpl
+++ b/modules/companies/Show.tpl
@@ -444,7 +444,7 @@ use OpenCATS\UI\QuickActionMenu;
                             <?php endif; ?>
                         </td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']); ?></td>
-                        <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['regarding']); ?></td>
+                        <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>" data-joborder-id="<?php echo(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']); ?></td>
                         <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br(htmlspecialchars($activityData['notes'], ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING))); ?></td>
                         <td align="center">
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>

--- a/modules/contacts/Show.tpl
+++ b/modules/contacts/Show.tpl
@@ -288,7 +288,7 @@ use OpenCATS\UI\QuickActionMenu;
                         <td align="left" valign="top" id="activityDate<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['dateCreated']) ?></td>
                         <td align="left" valign="top" id="activityType<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
-                        <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['regarding']) ?></td>
+                        <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>" data-joborder-id="<?php echo(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
                         <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br(htmlspecialchars($activityData['notes'], ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING))); ?></td>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1420,6 +1420,11 @@ class CATSSchema
             '373' => '
                 INSERT IGNORE INTO `activity_type` (`activity_type_id`, `short_description`) VALUES (800, \'Status Change\');
             ',
+            '374' => '
+                UPDATE `activity`
+                SET `joborder_id` = NULL
+                WHERE `joborder_id` IN (0, -1);
+            ',
 
         );
     }


### PR DESCRIPTION
This PR fixes an issue where editing an Activity could unintentionally reset the "Regarding" field from a specific Job Order to "General". The root cause was fragile preselection logic in the edit UI that relied on comparing rendered text, which could fail (for example when the dropdown option text includes markers like `(*)`).

The edit modal now preselects the correct Job Order using the underlying `jobOrderID` rather than display text. In addition, saving "General" is normalized so that `activity.joborder_id` is persisted as SQL `NULL` instead of inconsistent sentinel values created by legacy paths (such as `0` or `-1`).

Finally, the PR includes a schema migration that updates existing rows and converts legacy `activity.joborder_id` values of `0` and `-1` to `NULL`, ensuring "General" is represented consistently across old and new data.