### PR TITLE
refactor: migrate MyISAM tables to InnoDB

### DIFF
--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE `access_level` (
   `long_description` text COLLATE utf8_unicode_ci NOT NULL,
   PRIMARY KEY (`access_level_id`),
   KEY `IDX_access_level` (`short_description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `access_level` */
 
@@ -55,7 +55,7 @@ CREATE TABLE `activity` (
   KEY `IDX_data_item_id_type_site` (`site_id`,`data_item_id`,`data_item_type`),
   KEY `IDX_site_created` (`site_id`,`date_created`),
   KEY `IDX_activity_site_type_created_job` (`site_id`,`data_item_type`,`date_created`,`entered_by`,`joborder_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `activity` */
 
@@ -66,7 +66,7 @@ CREATE TABLE `activity_type` (
   `short_description` varchar(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`activity_type_id`),
   KEY `IDX_activity_type1` (`short_description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `activity_type` */
 
@@ -105,7 +105,7 @@ CREATE TABLE `attachment` (
   KEY `IDX_CANDIDATE_MD5_SUM` (`md5_sum`),
   KEY `IDX_site_file_size` (`site_id`,`file_size_kb`),
   KEY `IDX_site_file_size_created` (`site_id`,`file_size_kb`,`date_created`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `attachment` */
 
@@ -133,7 +133,7 @@ CREATE TABLE `calendar_event` (
   PRIMARY KEY (`calendar_event_id`),
   KEY `IDX_site_id_date` (`site_id`,`date`),
   KEY `IDX_site_data_item_type_id` (`site_id`,`data_item_type`,`data_item_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `calendar_event` */
 
@@ -145,7 +145,7 @@ CREATE TABLE `calendar_event_type` (
   `icon_image` varchar(128) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`calendar_event_type_id`),
   KEY `IDX_short_description` (`short_description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `calendar_event_type` */
 
@@ -209,7 +209,7 @@ CREATE TABLE `candidate` (
   KEY `IDX_date_modified` (`date_modified`),
   KEY `IDX_site_first_last_modified` (`site_id`,`first_name`,`last_name`,`date_modified`),
   KEY `IDX_site_id_email_1_2` (`site_id`,`email1`(8),`email2`(8))
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `candidate` */
 
@@ -222,7 +222,7 @@ CREATE TABLE `candidate_duplicates` (
   PRIMARY KEY (`old_candidate_id`, `new_candidate_id`),
   KEY `IDX_old_candidate_id` (`old_candidate_id`),
   KEY `IDX_new_candidate_id` (`new_candidate_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `candidate_duplicates` */
 
@@ -248,7 +248,7 @@ CREATE TABLE `candidate_joborder` (
   KEY `IDX_status_special` (`site_id`,`status`),
   KEY `IDX_site_joborder` (`site_id`,`joborder_id`),
   KEY `IDX_joborder_id` (`joborder_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `candidate_joborder` */
 
@@ -262,7 +262,7 @@ CREATE TABLE `candidate_joborder_status` (
   `is_enabled` int(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`candidate_joborder_status_id`),
   KEY `IDX_short_description` (`short_description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `candidate_joborder_status` */
 
@@ -295,7 +295,7 @@ CREATE TABLE `candidate_joborder_status_history` (
   KEY `IDX_candidate_joborder_status_to_site` (`candidate_id`,`joborder_id`,`status_to`,`site_id`),
   KEY `IDX_joborder_site` (`joborder_id`,`site_id`),
   KEY `IDX_site_joborder_status_to` (`site_id`,`joborder_id`,`status_to`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `candidate_joborder_status_history` */
 
@@ -307,7 +307,7 @@ CREATE TABLE `candidate_jobordrer_status_type` (
   `can_be_scheduled` int(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`candidate_status_type_id`),
   KEY `IDX_short_description` (`short_description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `candidate_jobordrer_status_type` */
 
@@ -320,7 +320,7 @@ CREATE TABLE `candidate_source` (
   `date_created` datetime DEFAULT NULL,
   PRIMARY KEY (`source_id`),
   KEY `siteID` (`site_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `candidate_source` */
 
@@ -332,7 +332,7 @@ CREATE TABLE `candidate_tag` (
   `candidate_id` int(10) unsigned NOT NULL,
   `tag_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Table structure for table `career_portal_questionnaire` */
 
@@ -343,7 +343,7 @@ CREATE TABLE `career_portal_questionnaire` (
   `description` varchar(255) DEFAULT NULL,
   `is_active` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`career_portal_questionnaire_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `career_portal_questionnaire` */
 
@@ -363,7 +363,7 @@ CREATE TABLE `career_portal_questionnaire_answer` (
   `position` int(4) NOT NULL DEFAULT '0',
   `site_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`career_portal_questionnaire_answer_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `career_portal_questionnaire_answer` */
 
@@ -379,7 +379,7 @@ CREATE TABLE `career_portal_questionnaire_history` (
   `questionnaire_description` varchar(255) NOT NULL DEFAULT '',
   `date` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   PRIMARY KEY (`career_portal_questionnaire_history_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `career_portal_questionnaire_history` */
 
@@ -396,7 +396,7 @@ CREATE TABLE `career_portal_questionnaire_question` (
   `site_id` int(11) NOT NULL DEFAULT '0',
   `type` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`career_portal_questionnaire_question_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `career_portal_questionnaire_question` */
 
@@ -408,7 +408,7 @@ CREATE TABLE `career_portal_template` (
   `setting` varchar(128) NOT NULL DEFAULT '',
   `value` text,
   PRIMARY KEY (`career_portal_template_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=23 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=23 DEFAULT CHARSET=utf8;
 
 /*Data for the table `career_portal_template` */
 
@@ -444,7 +444,7 @@ CREATE TABLE `career_portal_template_site` (
   `setting` varchar(128) NOT NULL DEFAULT '',
   `value` text,
   PRIMARY KEY (`career_portal_template_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `career_portal_template_site` */
 
@@ -482,7 +482,7 @@ CREATE TABLE `company` (
   KEY `IDX_date_created` (`date_created`),
   KEY `IDX_date_modified` (`date_modified`),
   KEY `IDX_is_hot` (`is_hot`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `company` */
 
@@ -498,7 +498,7 @@ CREATE TABLE `company_department` (
   `date_created` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   `created_by` int(11) DEFAULT NULL,
   PRIMARY KEY (`company_department_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `company_department` */
 
@@ -540,7 +540,7 @@ CREATE TABLE `contact` (
   KEY `IDX_owner` (`owner`),
   KEY `IDX_date_created` (`date_created`),
   KEY `IDX_date_modified` (`date_modified`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `contact` */
 
@@ -551,7 +551,7 @@ CREATE TABLE `data_item_type` (
   `short_description` varchar(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`data_item_type_id`),
   KEY `IDX_short_description` (`short_description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `data_item_type` */
 
@@ -566,7 +566,7 @@ CREATE TABLE `eeo_ethnic_type` (
   `eeo_ethnic_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `type` varchar(128) NOT NULL DEFAULT '',
   PRIMARY KEY (`eeo_ethnic_type_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
 
 /*Data for the table `eeo_ethnic_type` */
 
@@ -582,7 +582,7 @@ CREATE TABLE `eeo_veteran_type` (
   `eeo_veteran_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `type` varchar(128) NOT NULL DEFAULT '',
   PRIMARY KEY (`eeo_veteran_type_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
 
 /*Data for the table `eeo_veteran_type` */
 
@@ -605,7 +605,7 @@ CREATE TABLE `email_history` (
   KEY `IDX_site_id` (`site_id`),
   KEY `IDX_date` (`date`),
   KEY `IDX_user_id` (`user_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `email_history` */
 
@@ -621,7 +621,7 @@ CREATE TABLE `email_template` (
   `possible_variables` text COLLATE utf8_unicode_ci,
   `disabled` int(1) DEFAULT '0',
   PRIMARY KEY (`email_template_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `email_template` */
 
@@ -642,7 +642,7 @@ CREATE TABLE `extension_statistics` (
   `user` varchar(128) NOT NULL DEFAULT '',
   `date` date DEFAULT NULL,
   PRIMARY KEY (`extension_statistics_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `extension_statistics` */
 
@@ -659,7 +659,7 @@ CREATE TABLE `extra_field` (
   PRIMARY KEY (`extra_field_id`),
   KEY `assoc_id` (`data_item_id`),
   KEY `IDX_site_id` (`site_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `extra_field` */
 
@@ -676,7 +676,7 @@ CREATE TABLE `extra_field_settings` (
   `extra_field_options` text COLLATE utf8_unicode_ci,
   `position` int(4) NOT NULL DEFAULT '0',
   PRIMARY KEY (`extra_field_settings_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `extra_field_settings` */
 
@@ -698,7 +698,7 @@ CREATE TABLE `feedback` (
   `feedback` text COLLATE utf8_unicode_ci NOT NULL,
   `archived` int(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`feedback_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `feedback` */
 
@@ -718,7 +718,7 @@ CREATE TABLE `history` (
   PRIMARY KEY (`history_id`),
   KEY `IDX_DATA_ENTERED_BY` (`entered_by`),
   KEY `IDX_data_item_id_type_site` (`data_item_id`,`data_item_type`,`site_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `history` */
 
@@ -737,7 +737,7 @@ CREATE TABLE `http_log` (
   `log_type` int(11) NOT NULL,
   `date` datetime DEFAULT '1000-01-01 00:00:00',
   PRIMARY KEY (`log_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `http_log` */
 
@@ -749,7 +749,7 @@ CREATE TABLE `http_log_types` (
   `description` varchar(255) DEFAULT NULL,
   `default_log_type` tinyint(1) unsigned zerofill NOT NULL DEFAULT '0',
   PRIMARY KEY (`log_type_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 
 /*Data for the table `http_log_types` */
 
@@ -766,7 +766,7 @@ CREATE TABLE `import` (
   `added_lines` int(11) DEFAULT NULL,
   `date_created` datetime DEFAULT NULL,
   PRIMARY KEY (`import_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `import` */
 
@@ -775,7 +775,7 @@ CREATE TABLE `import` (
 CREATE TABLE `installtest` (
   `id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `installtest` */
 
@@ -824,7 +824,7 @@ CREATE TABLE `joborder` (
   KEY `IDX_date_created` (`date_created`),
   KEY `IDX_date_modified` (`date_modified`),
   KEY `IDX_site_id_status` (`site_id`,`status`(8))
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `joborder` */
 
@@ -835,7 +835,7 @@ CREATE TABLE `module_schema` (
   `name` varchar(64) COLLATE utf8_unicode_ci DEFAULT NULL,
   `version` int(11) DEFAULT NULL,
   PRIMARY KEY (`module_schema_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=25 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `module_schema` */
 
@@ -875,7 +875,7 @@ CREATE TABLE `mru` (
   `date_created` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   PRIMARY KEY (`mru_id`),
   KEY `IDX_user_site` (`user_id`,`site_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `mru` */
 
@@ -894,7 +894,7 @@ CREATE TABLE `queue` (
   `error` tinyint(1) unsigned DEFAULT '0',
   `response` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`queue_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `queue` */
 
@@ -916,7 +916,7 @@ CREATE TABLE `saved_list` (
   KEY `IDX_data_item_type` (`data_item_type`),
   KEY `IDX_description` (`description`),
   KEY `IDX_site_id` (`site_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `saved_list` */
 
@@ -934,7 +934,7 @@ CREATE TABLE `saved_list_entry` (
   KEY `IDX_data_item_type` (`data_item_type`),
   KEY `IDX_data_item_id` (`data_item_id`),
   KEY `IDX_hot_list_id` (`saved_list_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `saved_list_entry` */
 
@@ -950,7 +950,7 @@ CREATE TABLE `saved_search` (
   `site_id` int(11) DEFAULT NULL,
   `date_created` datetime DEFAULT NULL,
   PRIMARY KEY (`search_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `saved_search` */
 
@@ -963,7 +963,7 @@ CREATE TABLE `settings` (
   `site_id` int(11) NOT NULL DEFAULT '0',
   `settings_type` int(11) DEFAULT '0',
   PRIMARY KEY (`settings_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `settings` */
 
@@ -1002,7 +1002,7 @@ CREATE TABLE `site` (
   `limit_warning` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`site_id`),
   KEY `IDX_account_deleted` (`account_deleted`)
-) ENGINE=MyISAM AUTO_INCREMENT=181 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=181 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `site` */
 
@@ -1015,7 +1015,7 @@ CREATE TABLE `sph_counter` (
   `counter_id` int(11) NOT NULL,
   `max_doc_id` int(11) NOT NULL,
   PRIMARY KEY (`counter_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `sph_counter` */
 
@@ -1029,7 +1029,7 @@ CREATE TABLE `system` (
   `available_version_description` text COLLATE utf8_unicode_ci,
   `disable_version_check` int(1) DEFAULT '0',
   PRIMARY KEY (`system_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `system` */
 
@@ -1045,7 +1045,7 @@ CREATE TABLE `tag` (
   `site_id` int(11) unsigned DEFAULT NULL,
   `date_created` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`tag_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `tag` */
 
@@ -1085,7 +1085,7 @@ CREATE TABLE `user` (
   KEY `IDX_first_name` (`first_name`),
   KEY `IDX_last_name` (`last_name`),
   KEY `IDX_access_level` (`access_level`)
-) ENGINE=MyISAM AUTO_INCREMENT=1251 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1251 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user` */
 
@@ -1111,7 +1111,7 @@ CREATE TABLE `user_login` (
   KEY `IDX_date_refreshed` (`date_refreshed`),
   KEY `IDX_site_id_date` (`site_id`,`date`),
   KEY `IDX_successful_site_id` (`successful`,`site_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_login` */
 
@@ -1121,7 +1121,7 @@ CREATE TABLE `word_verification` (
   `word_verification_ID` int(11) NOT NULL AUTO_INCREMENT,
   `word` varchar(28) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`word_verification_ID`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `word_verification` */
 
@@ -1133,7 +1133,7 @@ CREATE TABLE `xml_feed_submits` (
   `feed_url` varchar(255) NOT NULL,
   `date_last_post` date NOT NULL,
   PRIMARY KEY (`feed_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `xml_feed_submits` */
 
@@ -1148,7 +1148,7 @@ CREATE TABLE `xml_feeds` (
   `success_string` varchar(255) NOT NULL,
   `xml_template_name` varchar(255) NOT NULL,
   PRIMARY KEY (`xml_feed_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
 
 /*Data for the table `xml_feeds` */
 
@@ -1163,7 +1163,7 @@ CREATE TABLE `zipcodes` (
   `state` varchar(2) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `areacode` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`zipcode`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `zipcodes` */
 

--- a/lib/DatabaseConnection.php
+++ b/lib/DatabaseConnection.php
@@ -719,7 +719,7 @@ class DatabaseConnection
     {
         if (!$this->_inTransaction)
         {
-            // Ignore errors (if called for MyISAM, for example)
+            // Ignore errors (e.g., if transactions are not supported by the underlying storage engine)
             $this->query('BEGIN', true);
             return ($this->_inTransaction = true);
         }

--- a/lib/InstallationTests.php
+++ b/lib/InstallationTests.php
@@ -422,11 +422,11 @@ class InstallationTests
         );
 
         /* Check CREATE TABLE permissions. */
-        $queryResult = @mysqli_query($db, 'CREATE TABLE `testtable` (`id` int(11) NOT NULL default \'0\') ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;');
+        $queryResult = @mysqli_query($db, 'CREATE TABLE `testtable` (`id` int(11) NOT NULL default \'0\') ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;');
         if (!$queryResult)
         {
             mysqli_query($db, 'DROP TABLE testtable');
-            $queryResult = @mysqli_query($db, 'CREATE TABLE `testtable` (`id` int(11) NOT NULL default \'0\') ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;');
+            $queryResult = @mysqli_query($db, 'CREATE TABLE `testtable` (`id` int(11) NOT NULL default \'0\') ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;');
         }
         if (!$queryResult)
         {

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1425,6 +1425,23 @@ class CATSSchema
                 SET `joborder_id` = NULL
                 WHERE `joborder_id` IN (0, -1);
             ',
+            '375' => 'PHP:
+                $rs = $db->getAllAssoc(
+                    "SELECT
+                        TABLE_NAME AS table_name
+                     FROM
+                        information_schema.TABLES
+                     WHERE
+                        TABLE_SCHEMA = DATABASE()
+                        AND TABLE_TYPE = \'BASE TABLE\'
+                        AND ENGINE = \'MyISAM\'"
+                );
+
+                foreach ($rs as $rowIndex => $row)
+                {
+                    $db->query("ALTER TABLE `".$row[\'table_name\']."` ENGINE=InnoDB");
+                }
+            ',
 
         );
     }


### PR DESCRIPTION
## Summary

This PR switches OpenCATS' default database table engine from MyISAM to InnoDB for new installations and adds a schema upgrade step that converts existing MyISAM tables to InnoDB.

## Motivation

InnoDB is the modern default engine for MySQL/MariaDB and provides better transactional safety, crash recovery and concurrency characteristics than MyISAM.
