### PR TITLE
security: restrict AJAX during upgrade and escape installer config writes

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -106,6 +106,31 @@ if (!isset($_REQUEST['f']) || empty($_REQUEST['f']))
     die();
 }
 
+$installerActive = (!file_exists('INSTALL_BLOCK'));
+if ($installerActive)
+{
+    $module = '';
+    if (strpos($_REQUEST['f'], ':') !== false)
+    {
+        $parameters = explode(':', $_REQUEST['f']);
+        $module = preg_replace("/[^A-Za-z0-9]/", "", $parameters[0]);
+    }
+
+    if ($module !== 'install')
+    {
+        header('Content-type: text/xml');
+        echo '<?xml version="1.0" encoding="', AJAX_ENCODING, '"?>', "\n";
+        echo(
+            "<data>\n" .
+            "    <errorcode>-1</errorcode>\n" .
+            "    <errormessage>Installer is active. Only installer AJAX actions are allowed.</errormessage>\n" .
+            "</data>\n"
+        );
+
+        die();
+    }
+}
+
 if (strpos($_REQUEST['f'], ':') === false)
 {
     $function = preg_replace("/[^A-Za-z0-9]/", "", $_REQUEST['f']);

--- a/modules/install/ajax/ui.php
+++ b/modules/install/ajax/ui.php
@@ -124,22 +124,22 @@ switch ($action)
         {
             if (isset($_REQUEST['user']) && !empty($_REQUEST['user']))
             {
-                CATSUtility::changeConfigSetting('DATABASE_USER', "'" . $_REQUEST['user'] . "'");
+                CATSUtility::changeConfigSetting('DATABASE_USER', var_export($_REQUEST['user'], true));
             }
 
             if (isset($_REQUEST['pass']) && $_REQUEST['pass'] !== '')
             {
-                CATSUtility::changeConfigSetting('DATABASE_PASS', "'" . $_REQUEST['pass'] . "'");
+                CATSUtility::changeConfigSetting('DATABASE_PASS', var_export($_REQUEST['pass'], true));
             }
 
             if (isset($_REQUEST['host']) && !empty($_REQUEST['host']))
             {
-                CATSUtility::changeConfigSetting('DATABASE_HOST', "'" . $_REQUEST['host'] . "'");
+                CATSUtility::changeConfigSetting('DATABASE_HOST', var_export($_REQUEST['host'], true));
             }
 
             if (isset($_REQUEST['name']) && !empty($_REQUEST['name']))
             {
-                CATSUtility::changeConfigSetting('DATABASE_NAME', "'" . $_REQUEST['name'] . "'");
+                CATSUtility::changeConfigSetting('DATABASE_NAME', var_export($_REQUEST['name'], true));
             }
 
             echo '
@@ -244,11 +244,11 @@ switch ($action)
                 CATSUtility::changeConfigSetting('MAIL_SMTP_AUTH', 'false');
             }
 
-            CATSUtility::changeConfigSetting('MAIL_SENDMAIL_PATH', '"' . $mailSendmailPath . '"');
-            CATSUtility::changeConfigSetting('MAIL_SMTP_HOST', '"' . $mailSmtpHost . '"');
+            CATSUtility::changeConfigSetting('MAIL_SENDMAIL_PATH', var_export($mailSendmailPath, true));
+            CATSUtility::changeConfigSetting('MAIL_SMTP_HOST', var_export($mailSmtpHost, true));
             CATSUtility::changeConfigSetting('MAIL_SMTP_PORT', sprintf('%d', $mailSmtpPort));
-            CATSUtility::changeConfigSetting('MAIL_SMTP_USER', '"' . $mailSmtpUsername . '"');
-            CATSUtility::changeConfigSetting('MAIL_SMTP_PASS', '"' . $mailSmtpPassword . '"');
+            CATSUtility::changeConfigSetting('MAIL_SMTP_USER', var_export($mailSmtpUsername, true));
+            CATSUtility::changeConfigSetting('MAIL_SMTP_PASS', var_export($mailSmtpPassword, true));
 
             @session_name(CATS_SESSION_NAME);
             session_start();
@@ -420,20 +420,16 @@ switch ($action)
             </script>';
 
         $antiwordPath = $_REQUEST['docExecutable'];
-        $antiwordWithSlashes = str_replace('\\', '\\\\', $antiwordPath);
-        CATSUtility::changeConfigSetting('ANTIWORD_PATH', '"' . $antiwordWithSlashes . '"');
+        CATSUtility::changeConfigSetting('ANTIWORD_PATH', var_export($antiwordPath, true));
 
         $pdftotextPath = $_REQUEST['pdfExecutable'];
-        $pdftotextWithSlashes = str_replace('\\', '\\\\', $pdftotextPath);
-        CATSUtility::changeConfigSetting('PDFTOTEXT_PATH', '"' . $pdftotextWithSlashes . '"');
+        CATSUtility::changeConfigSetting('PDFTOTEXT_PATH', var_export($pdftotextPath, true));
 
         $html2textPath = $_REQUEST['htmlExecutable'];
-        $html2textWithSlashes = str_replace('\\', '\\\\', $html2textPath);
-        CATSUtility::changeConfigSetting('HTML2TEXT_PATH', '"' . $html2textWithSlashes . '"');
+        CATSUtility::changeConfigSetting('HTML2TEXT_PATH', var_export($html2textPath, true));
 
         $unrtfPath = $_REQUEST['rtfExecutable'];
-        $unrtfWithSlashes = str_replace('\\', '\\\\', $unrtfPath);
-        CATSUtility::changeConfigSetting('UNRTF_PATH', '"' . $unrtfWithSlashes . '"');
+        CATSUtility::changeConfigSetting('UNRTF_PATH', var_export($unrtfPath, true));
 
         break;
 


### PR DESCRIPTION
## Summary

When upgrade mode is active and `INSTALL_BLOCK` is missing, `ajax.php` now only allows installer AJAX actions (`install:*`). All other AJAX requests are rejected early with the standard XML error response.

This PR also hardens installer config writes in `modules/install/ajax/ui.php` by escaping string values before passing them to `CATSUtility::changeConfigSetting()`. The affected installer settings now use safe PHP string literals via `var_export($value, true)` before being written to `config.php`.

## Motivation

During upgrades, `index.php` is already blocked when `INSTALL_BLOCK` is missing, but `ajax.php` remained accessible. That could allow existing sessions or stale UI tabs to continue sending AJAX requests while schema migrations are running, increasing the risk of unintended changes or inconsistent state.

Review also identified that several installer config values were still passed unescaped into `CATSUtility::changeConfigSetting()`, which then writes them directly into executable PHP in `config.php`. Escaping those values closes that remaining installer hardening gap without changing the intended installer flow.