### PR TITLE
security: add IP-based login throttling

### DIFF
--- a/lib/Session.php
+++ b/lib/Session.php
@@ -676,6 +676,36 @@ class CATSSession
             $this->_isLoggedIn = false;
             $this->_loginError = 'Invalid username or password.';
 
+            if (isset($_SERVER['REMOTE_ADDR']))
+            {
+                $ip = $_SERVER['REMOTE_ADDR'];
+            }
+            else
+            {
+                $ip = '';
+            }
+
+            if (isset($_SERVER['HTTP_USER_AGENT']))
+            {
+                $userAgent = $_SERVER['HTTP_USER_AGENT'];
+            }
+            else
+            {
+                $userAgent = '';
+            }
+
+            /* Log the login as unsuccessful. */
+            if ($addToHistory)
+            {
+                $users->addLoginHistory(
+                    null,
+                    0,
+                    $ip,
+                    $userAgent,
+                    false
+                );
+            }
+
             return;
         }
 

--- a/lib/Users.php
+++ b/lib/Users.php
@@ -973,6 +973,20 @@ class Users
     public function addLoginHistory($userID, $siteID, $ip, $userAgent,
             $wasSuccessful)
     {
+        if ($userID === null || $userID === '')
+        {
+            $userIDSQL = 'NULL';
+        }
+        else
+        {
+            $userIDSQL = $this->_db->makeQueryInteger($userID);
+        }
+
+        if ($siteID === null || $siteID === '')
+        {
+            $siteID = 0;
+        }
+
         if (ENABLE_HOSTNAME_LOOKUP)
         {
             $hostname = @gethostbyaddr($ip);
@@ -1003,8 +1017,8 @@ class Users
                     %s,
                     NOW()
                     )",
-            $userID,
-            $siteID,
+            $userIDSQL,
+            $this->_db->makeQueryInteger($siteID),
             $this->_db->makeQueryString($ip),
             $this->_db->makeQueryString($userAgent),
             $this->_db->makeQueryString($hostname),

--- a/lib/Users.php
+++ b/lib/Users.php
@@ -971,6 +971,20 @@ class Users
     public function addLoginHistory($userID, $siteID, $ip, $userAgent,
             $wasSuccessful)
     {
+        if ($userID === null || $userID === '')
+        {
+            $userIDSQL = 'NULL';
+        }
+        else
+        {
+            $userIDSQL = $this->_db->makeQueryInteger($userID);
+        }
+
+        if ($siteID === null || $siteID === '')
+        {
+            $siteID = 0;
+        }
+
         if (ENABLE_HOSTNAME_LOOKUP)
         {
             $hostname = @gethostbyaddr($ip);
@@ -1001,8 +1015,8 @@ class Users
                     %s,
                     NOW()
                     )",
-            $userID,
-            $siteID,
+            $userIDSQL,
+            $this->_db->makeQueryInteger($siteID),
             $this->_db->makeQueryString($ip),
             $this->_db->makeQueryString($userAgent),
             $this->_db->makeQueryString($hostname),

--- a/test/features/GET_POST_requestsSecurity.feature
+++ b/test/features/GET_POST_requestsSecurity.feature
@@ -3,7 +3,7 @@ Feature: Security using ACL - actions - GET & POST
   In order to protect sensitive information from users who shouldd not have access to them
   All accesses in the system need to be controlled by the Access Control List
 
-@candidates @actions
+@candidates @actions @reset_login_attempts
 Scenario Outline: Candidate module actions
   Given I am logged in with <accessLevel> access level
   
@@ -239,7 +239,7 @@ Scenario Outline: Candidate module actions
   
   
 
-@joborders @actions
+@joborders @actions @reset_login_attempts
 Scenario Outline: Job Order module actions
   Given I am logged in with <accessLevel> access level
   
@@ -443,7 +443,7 @@ Scenario Outline: Job Order module actions
   
  
   
- @companies @actions
+ @companies @actions @reset_login_attempts
  Scenario Outline: Companies module actions
   Given I am logged in with <accessLevel> access level
   
@@ -574,7 +574,7 @@ Examples:
   | ROOT        | POST | index.php?m=companies&a=deleteAttachment   |      |
 
 
-@contacts @actions
+@contacts @actions @reset_login_attempts
 Scenario Outline: Contacts module actions
   Given I am logged in with <accessLevel> access level
   
@@ -696,7 +696,7 @@ Scenario Outline: Contacts module actions
   | ROOT        | POST    | index.php?m=contacts&a=addActivityScheduleEvent |       |    
   | ROOT        | POST    | index.php?m=contacts&a=delete                   |       |
   
-@activities @actions
+@activities @actions @reset_login_attempts
 Scenario Outline: Activity module actions
   Given I am logged in with <accessLevel> access level
   
@@ -730,7 +730,7 @@ Scenario Outline: Activity module actions
   | ROOT        | GET  | index.php?m=activity&a=listByViewDataGrid  |      |  
   | ROOT        | POST | index.php?m=activity&a=viewByDate          |      |
   
-@dashboard @home @actions
+@dashboard @home @actions @reset_login_attempts
 Scenario Outline: Home module actions
   Given I am logged in with <accessLevel> access level
   
@@ -796,7 +796,7 @@ Scenario Outline: Home module actions
   | ROOT        | POST | index.php?m=home&a=deleteSavedSearch   |      |
   | ROOT        | POST | index.php?m=home&a=addSavedSearch      |      |
   
-@lists @actions
+@lists @actions @reset_login_attempts
 Scenario Outline: Lists module actions
   Given I am logged in with <accessLevel> access level
   
@@ -871,7 +871,7 @@ Scenario Outline: Lists module actions
   | ROOT        | GET  | index.php?m=lists&a=listByView                 |      |
   
  
-@calendar @actions
+@calendar @actions @reset_login_attempts
 Scenario Outline: Calendar module actions
   Given I am logged in with <accessLevel> access level
   
@@ -921,7 +921,7 @@ Scenario Outline: Calendar module actions
   | ROOT        | POST | index.php?m=calendar&a=addEvent                |      |
   | ROOT        | POST | index.php?m=calendar&a=editEvent               |      |
   
-@reports @actions
+@reports @actions @reset_login_attempts
 Scenario Outline: Reports module actions
   Given I am logged in with <accessLevel> access level
   
@@ -995,7 +995,7 @@ Scenario Outline: Reports module actions
   | ROOT        | GET  | index.php?m=reports&a=generateEEOReportPreview     |      |
   | ROOT        | GET  | index.php?m=reports&a=reports                      |      |
   
- @settings @actions
+ @settings @actions @reset_login_attempts
   Scenario Outline: Settings module actions
   Given I am logged in with <accessLevel> access level
   

--- a/test/features/GET_POST_requestsSecurity.feature
+++ b/test/features/GET_POST_requestsSecurity.feature
@@ -3,7 +3,7 @@ Feature: Security using ACL - actions - GET & POST
   In order to protect sensitive information from users who shouldd not have access to them
   All accesses in the system need to be controlled by the Access Control List
 
-@candidates @actions
+@candidates @actions @reset_login_attempts
 Scenario Outline: Candidate module actions
   Given I am logged in with <accessLevel> access level
   
@@ -255,7 +255,7 @@ Scenario Outline: Candidate module actions
   
   
 
-@joborders @actions
+@joborders @actions @reset_login_attempts
 Scenario Outline: Job Order module actions
   Given I am logged in with <accessLevel> access level
   
@@ -475,7 +475,7 @@ Scenario Outline: Job Order module actions
   
  
   
- @companies @actions
+ @companies @actions @reset_login_attempts
  Scenario Outline: Companies module actions
   Given I am logged in with <accessLevel> access level
   
@@ -606,7 +606,7 @@ Examples:
   | ROOT        | POST | index.php?m=companies&a=deleteAttachment   |      |
 
 
-@contacts @actions
+@contacts @actions @reset_login_attempts
 Scenario Outline: Contacts module actions
   Given I am logged in with <accessLevel> access level
   
@@ -728,7 +728,7 @@ Scenario Outline: Contacts module actions
   | ROOT        | POST    | index.php?m=contacts&a=addActivityScheduleEvent |       |    
   | ROOT        | POST    | index.php?m=contacts&a=delete                   |       |
   
-@activities @actions
+@activities @actions @reset_login_attempts
 Scenario Outline: Activity module actions
   Given I am logged in with <accessLevel> access level
   
@@ -762,7 +762,7 @@ Scenario Outline: Activity module actions
   | ROOT        | GET  | index.php?m=activity&a=listByViewDataGrid  |      |  
   | ROOT        | POST | index.php?m=activity&a=viewByDate          |      |
   
-@dashboard @home @actions
+@dashboard @home @actions @reset_login_attempts
 Scenario Outline: Home module actions
   Given I am logged in with <accessLevel> access level
   
@@ -828,7 +828,7 @@ Scenario Outline: Home module actions
   | ROOT        | POST | index.php?m=home&a=deleteSavedSearch   |      |
   | ROOT        | POST | index.php?m=home&a=addSavedSearch      |      |
   
-@lists @actions
+@lists @actions @reset_login_attempts
 Scenario Outline: Lists module actions
   Given I am logged in with <accessLevel> access level
   
@@ -903,7 +903,7 @@ Scenario Outline: Lists module actions
   | ROOT        | GET  | index.php?m=lists&a=listByView                 |      |
   
  
-@calendar @actions
+@calendar @actions @reset_login_attempts
 Scenario Outline: Calendar module actions
   Given I am logged in with <accessLevel> access level
   
@@ -953,7 +953,7 @@ Scenario Outline: Calendar module actions
   | ROOT        | POST | index.php?m=calendar&a=addEvent                |      |
   | ROOT        | POST | index.php?m=calendar&a=editEvent               |      |
   
-@reports @actions
+@reports @actions @reset_login_attempts
 Scenario Outline: Reports module actions
   Given I am logged in with <accessLevel> access level
   
@@ -1027,7 +1027,7 @@ Scenario Outline: Reports module actions
   | ROOT        | GET  | index.php?m=reports&a=generateEEOReportPreview     |      |
   | ROOT        | GET  | index.php?m=reports&a=reports                      |      |
   
- @settings @actions
+ @settings @actions @reset_login_attempts
   Scenario Outline: Settings module actions
   Given I am logged in with <accessLevel> access level
   

--- a/test/features/bootstrap/SecurityContext.php
+++ b/test/features/bootstrap/SecurityContext.php
@@ -81,6 +81,40 @@ class SecurityContext extends MinkContext implements Context, SnippetAcceptingCo
     }
 
     /**
+     * Test-only: Some security scenarios intentionally perform many failed login attempts (e.g. disabled users).
+     * This can accumulate rows in `user_login` and trigger the IP-based brute-force lockout, which then breaks
+     * subsequent login steps within the same CI run. For scenarios tagged with @reset_login_attempts, reset the
+     * login attempt history to keep tests isolated from this side effect.
+     *
+     * @BeforeScenario
+     */
+    public function resetLoginAttemptsForScenario($event)
+    {
+        $scenario = $event->getScenario();
+        if (method_exists($scenario, 'hasTag'))
+        {
+            $hasTag = $scenario->hasTag('reset_login_attempts');
+        }
+        else
+        {
+            $tags = $scenario->getTags();
+            $hasTag = in_array('reset_login_attempts', $tags, true);
+        }
+
+        if (!$hasTag)
+        {
+            return;
+        }
+
+        $db = DatabaseConnection::getInstance();
+        $result = $db->query('TRUNCATE TABLE user_login');
+        if ($result === false)
+        {
+            throw new Exception('Failed to truncate user_login for scenario: ' . $scenario->getTitle());
+        }
+    }
+
+    /**
      * @Given I am logged in with :accessLevel access level
      */
     public function iAmLoggedInWithAccessLevel($accessLevel)

--- a/test/features/moduleMainPagesSecurity.feature
+++ b/test/features/moduleMainPagesSecurity.feature
@@ -5,7 +5,7 @@ Feature: Access Level to objects check - main pages
   
   ######## DASHBOARD(HOME) #######
 
-  @javascript @dashboard
+  @javascript @dashboard @reset_login_attempts
   Scenario Outline: Dashboard module visibility
     Given I am logged in with <accessLevel> access level
     And I am on "/index.php?m=home"
@@ -32,7 +32,7 @@ Feature: Access Level to objects check - main pages
      
   ####### ACTIVITIES #######
     
-  @javascript @activities
+  @javascript @activities @reset_login_attempts
   Scenario Outline: Activities module visibility
     Given I am logged in with <accessLevel> access level
     And I am on "/index.php?m=activity"
@@ -64,7 +64,7 @@ Feature: Access Level to objects check - main pages
      
   ####### JOB ORDERS #######
     
-  @javascript @joborders
+  @javascript @joborders @reset_login_attempts
   Scenario Outline: Job Orders module visibility
     Given I am logged in with <accessLevel> access level
     And I am on "/index.php?m=joborders"
@@ -98,7 +98,7 @@ Feature: Access Level to objects check - main pages
      
   ####### CANDIDATES #######
      
-  @javascript @candidates
+  @javascript @candidates @reset_login_attempts
   Scenario Outline: Candidates module visibility
     Given I am logged in with <accessLevel> access level
     And I am on "/index.php?m=candidates"
@@ -134,7 +134,7 @@ Feature: Access Level to objects check - main pages
 
     ####### COMPANIES #######
     
-    @javascript @companies
+    @javascript @companies @reset_login_attempts
     Scenario Outline: Companies module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=companies"
@@ -167,7 +167,7 @@ Feature: Access Level to objects check - main pages
      
    ####### CONTACTS #######
      
-   @javascript @contacts
+   @javascript @contacts @reset_login_attempts
    Scenario Outline: Contacts module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=contacts"
@@ -201,7 +201,7 @@ Feature: Access Level to objects check - main pages
      
      ####### LISTS #######
      
-    @javascript @lists
+    @javascript @lists @reset_login_attempts
     Scenario Outline: Lists module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=lists"
@@ -227,7 +227,7 @@ Feature: Access Level to objects check - main pages
      
        ####### REPORTS #######
   
-  @javascript @reports
+  @javascript @reports @reset_login_attempts
     Scenario Outline: Reports module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=reports"
@@ -257,7 +257,7 @@ Feature: Access Level to objects check - main pages
      
 ####### SETTINGS #######  
 
-@javascript @settings
+@javascript @settings @reset_login_attempts
     Scenario Outline: Settings module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=settings"
@@ -283,7 +283,7 @@ Feature: Access Level to objects check - main pages
      
 ####### CALENDAR #######
 
-  @javascript @calendar
+  @javascript @calendar @reset_login_attempts
     Scenario Outline: Calendar module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=calendar"

--- a/test/features/moduleSubPagesSecurity.feature
+++ b/test/features/moduleSubPagesSecurity.feature
@@ -11,7 +11,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
  
   ####### JOB ORDERS #######  
        
-  @javascript @joborders
+  @javascript @joborders @reset_login_attempts
   Scenario Outline: Job Order Show page visibility
     Given I am logged in with <accessLevel> access level
     And I am on "/index.php?m=joborders"
@@ -50,7 +50,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
   
   ####### CANDIDATES #######
   
-   @javascript @candidates
+   @javascript @candidates @reset_login_attempts
    Scenario Outline: Candidate Show page visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=candidates"
@@ -93,7 +93,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
      
     ####### COMPANIES #######
 
-    @javascript @companies
+    @javascript @companies @reset_login_attempts
     Scenario Outline: Company Show page visibility for disabled level
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=home"
@@ -153,7 +153,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
      
   ####### CONTACTS #######
   
-  @javascript @contacts
+  @javascript @contacts @reset_login_attempts
     Scenario Outline: Contacts Show page visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=contacts"
@@ -187,7 +187,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
      
    ####### LISTS #######
        
-   @javascript @lists
+   @javascript @lists @reset_login_attempts
    Scenario Outline: Lists Show page visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=lists"


### PR DESCRIPTION
This PR adds a simple brute-force protection for the OpenCATS login by rate-limiting failed login attempts per IP address.

If an IP address has more than 10 failed login attempts within the last 10 minutes, further login attempts from that IP are blocked early (before any credential validation) and a generic error message is shown.

To prevent bypassing the IP throttle by trying random usernames, failed attempts for unknown usernames are now also written to `user_login` (with `user_id = NULL` and `site_id = 0`).