### PR TITLE
refactor: stop persisting inline HTML for status change activity notes

### DIFF
--- a/ajax/editActivity.php
+++ b/ajax/editActivity.php
@@ -28,9 +28,7 @@
  */
 
 
-include_once(LEGACY_ROOT . '/lib/StringUtility.php');
 include_once(LEGACY_ROOT . '/lib/ActivityEntries.php');
-include_once(LEGACY_ROOT . '/lib/Pipelines.php');
 
 
 $interface = new SecureAJAXInterface();
@@ -108,22 +106,6 @@ $date = sprintf(
     ),
     date('H:i:00', $time)
 );
-
-/* Highlight what needs highlighting. */
-if (strpos($activityNote, 'Status change: ') === 0)
-{
-    $pipelines = new Pipelines($siteID);
-
-    $statusRS = $pipelines->getStatusesForPicking();
-    foreach ($statusRS as $data)
-    {
-        $activityNote = StringUtility::replaceOnce(
-            $data['status'],
-            '<span style="color: #ff6c00;">' . $data['status'] . '</span>',
-            $activityNote
-        );
-    }
-}
 
 /* Save the new activity entry. */
 $activityEntries = new ActivityEntries($siteID);

--- a/ajax/editActivity.php
+++ b/ajax/editActivity.php
@@ -109,22 +109,6 @@ $date = sprintf(
     date('H:i:00', $time)
 );
 
-/* Highlight what needs highlighting. */
-if (strpos($activityNote, 'Status change: ') === 0)
-{
-    $pipelines = new Pipelines($siteID);
-
-    $statusRS = $pipelines->getStatusesForPicking();
-    foreach ($statusRS as $data)
-    {
-        $activityNote = StringUtility::replaceOnce(
-            $data['status'],
-            '<span style="color: #ff6c00;">' . $data['status'] . '</span>',
-            $activityNote
-        );
-    }
-}
-
 /* Save the new activity entry. */
 $activityEntries = new ActivityEntries($siteID);
 $activityEntries->update($activityID, $type, $activityNote, $jobOrderID, $date, $_SESSION['CATS']->getTimeZoneOffset());

--- a/lib/TemplateUtility.php
+++ b/lib/TemplateUtility.php
@@ -1080,6 +1080,32 @@ class TemplateUtility
     }
 
     /**
+     * Highlights status change activity notes for HTML output.
+     *
+     * @param string activity note text
+     * @return string updated activity note
+     */
+    public static function highlightStatusChangeActivityNote($notes)
+    {
+        $prefix = 'Status change: ';
+        if (strpos($notes, $prefix) !== 0)
+        {
+            return htmlspecialchars($notes, ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING);
+        }
+
+        $statusText = ltrim(substr($notes, strlen($prefix)));
+        if ($statusText === '')
+        {
+            return htmlspecialchars($notes, ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING);
+        }
+
+        return htmlspecialchars($prefix, ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING) .
+            '<span class="statusChangeHighlight">' .
+            htmlspecialchars($statusText, ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING) .
+            '</span>';
+    }
+
+    /**
      * Removes from $text everything from starting block through ending block.
      * Optionally also removes a following piece of text indicated by closing
      * tag.

--- a/lib/TemplateUtility.php
+++ b/lib/TemplateUtility.php
@@ -1080,6 +1080,32 @@ class TemplateUtility
     }
 
     /**
+     * Escapes activity notes and highlights status change text at render time.
+     *
+     * @param string activity note text
+     * @return string escaped notes with optional status text highlight
+     */
+    public static function highlightStatusChangeActivityNote($notes)
+    {
+        $statusPrefix = 'Status change: ';
+        if (strpos($notes, $statusPrefix) !== 0)
+        {
+            return Template::escapeHtml($notes);
+        }
+
+        $statusText = substr($notes, strlen($statusPrefix));
+        if ($statusText === '')
+        {
+            return Template::escapeHtml($notes);
+        }
+
+        return Template::escapeHtml($statusPrefix)
+            . '<span class="statusChangeHighlight">'
+            . Template::escapeHtml($statusText)
+            . '</span>';
+    }
+
+    /**
      * Removes from $text everything from starting block through ending block.
      * Optionally also removes a following piece of text indicated by closing
      * tag.

--- a/main.css
+++ b/main.css
@@ -905,6 +905,11 @@ span.jobLinkSubmitted
     color: #ff6c00;
 }
 
+span.statusChangeHighlight
+{
+    color: #ff6c00;
+}
+
 a.jobLinkSubmitted:hover
 {
     text-decoration: underline;

--- a/modules/activity/Search.tpl
+++ b/modules/activity/Search.tpl
@@ -77,7 +77,7 @@
                             </td>
 
                             <td align="left" valign="top" >
-                                <?php echo(nl2br($activityData['notes'])); ?>
+                                <?php echo(nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes']))); ?>
                             </td>
 
                             <td align="left" valign="top">

--- a/modules/activity/Search.tpl
+++ b/modules/activity/Search.tpl
@@ -77,7 +77,7 @@
                             </td>
 
                             <td align="left" valign="top" >
-                                <?php echo nl2br(Template::escapeHtml($activityData['notes'])); ?>
+                                <?php echo nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes'])); ?>
                             </td>
 
                             <td align="left" valign="top">

--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -3056,19 +3056,6 @@ class CandidatesUI extends UserInterface
 
             $activityNote = htmlspecialchars($activityNote);
 
-            // FIXME: Move this to a highlighter-method? */
-            if (strpos($activityNote, 'Status change: ') === 0)
-            {
-                foreach ($statusRS as $data)
-                {
-                    $activityNote = StringUtility::replaceOnce(
-                        $data['status'],
-                        '<span style="color: #ff6c00;">' . $data['status'] . '</span>',
-                        $activityNote
-                    );
-                }
-            }
-
             /* Add the activity entry. */
             $activityID = $activityEntries->add(
                 $candidateID,

--- a/modules/candidates/Show.tpl
+++ b/modules/candidates/Show.tpl
@@ -640,7 +640,7 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                         <td align="left" valign="top" id="activityType<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>" data-joborder-id="<?php echo(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
-                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br($activityData['notes'])); ?></td>
+                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes']))); ?></td>
 <?php if (!$this->isPopup): ?>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('candidates.edit') >= ACCESS_LEVEL_EDIT): ?>

--- a/modules/candidates/Show.tpl
+++ b/modules/candidates/Show.tpl
@@ -640,7 +640,7 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                         <td align="left" valign="top" id="activityType<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
-                        <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(Template::escapeHtml($activityData['notes'])); ?></td>
+                        <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes'])); ?></td>
 <?php if (!$this->isPopup): ?>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('candidates.edit') >= ACCESS_LEVEL_EDIT): ?>

--- a/modules/contacts/Show.tpl
+++ b/modules/contacts/Show.tpl
@@ -289,7 +289,7 @@ use OpenCATS\UI\QuickActionMenu;
                         <td align="left" valign="top" id="activityType<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
-                        <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(Template::escapeHtml($activityData['notes'])); ?></td>
+                        <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes'])); ?></td>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>
                                 <a href="#" id="editActivity<?php echo Template::escapeAttr($activityData['activityID']); ?>" onclick="Activity_editEntry(<?php echo (int) $activityData['activityID']; ?>, <?php echo (int) $this->contactID; ?>, <?php echo (int) DATA_ITEM_CONTACT; ?>, <?php echo Template::escapeJsAttr($this->sessionCookie); ?>); return false;">

--- a/modules/contacts/Show.tpl
+++ b/modules/contacts/Show.tpl
@@ -289,7 +289,7 @@ use OpenCATS\UI\QuickActionMenu;
                         <td align="left" valign="top" id="activityType<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>" data-joborder-id="<?php echo(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
-                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br(htmlspecialchars($activityData['notes'], ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING))); ?></td>
+                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes']))); ?></td>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>
                                 <a href="#" id="editActivity<?php echo($activityData['activityID']); ?>" onclick="Activity_editEntry(<?php echo($activityData['activityID']); ?>, <?php echo($this->contactID); ?>, <?php echo(DATA_ITEM_CONTACT); ?>, '<?php echo($this->sessionCookie); ?>'); return false;">

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1442,6 +1442,56 @@ class CATSSchema
                     $db->query("ALTER TABLE `".$row[\'table_name\']."` ENGINE=InnoDB");
                 }
             ',
+            '376' => 'PHP:
+                $lastActivityID = 0;
+                $batchSize = 200;
+                $highlightPattern = "/<span\\b(?=[^>]*\\bstyle\\s*=\\s*([\\"\\\']).*?\\bcolor\\s*:\\s*#ff6c00\\s*;?.*?\\1)[^>]*>(.*?)<\\/span>/is";
+
+                while (true)
+                {
+                    $activityRS = $db->getAllAssoc(
+                        "SELECT
+                            activity_id,
+                            notes
+                         FROM
+                            activity
+                         WHERE
+                            activity_id > " . $lastActivityID . "
+                            AND notes LIKE \'%<span%\'
+                            AND notes LIKE \'%#ff6c00%\'
+                         ORDER BY
+                            activity_id ASC
+                         LIMIT " . $batchSize
+                    );
+
+                    if (empty($activityRS))
+                    {
+                        break;
+                    }
+
+                    foreach ($activityRS as $rowIndex => $row)
+                    {
+                        $updatedNotes = preg_replace($highlightPattern, \'$2\', $row[\'notes\']);
+
+                        if ($updatedNotes === null)
+                        {
+                            $lastActivityID = (int) $row[\'activity_id\'];
+                            continue;
+                        }
+
+                        if ($updatedNotes !== $row[\'notes\'])
+                        {
+                            $db->query(
+                                "UPDATE activity
+                                 SET notes = " . $db->makeQueryString($updatedNotes) . "
+                                 WHERE activity_id = " . (int) $row[\'activity_id\']
+                            );
+                        }
+
+                        $lastActivityID = (int) $row[\'activity_id\'];
+                    }
+                }
+            ',
 
         );
     }

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1447,6 +1447,53 @@ class CATSSchema
                 SET short_description = \'Not reached\'
                 WHERE activity_type_id = 100;
             ',
+            '377' => 'PHP:
+                $lastActivityID = 0;
+                $batchSize = 200;
+
+                while (true)
+                {
+                    $rows = $db->getAllAssoc(
+                        "SELECT activity_id, notes
+                         FROM activity
+                         WHERE activity_id > " . (int) $lastActivityID . "
+                           AND notes LIKE \'Status change: %\'
+                           AND notes LIKE \'%<span%\'
+                           AND notes LIKE \'%#ff6c00%\'
+                         ORDER BY activity_id ASC
+                         LIMIT " . (int) $batchSize
+                    );
+
+                    if (empty($rows))
+                    {
+                        break;
+                    }
+
+                    foreach ($rows as $row)
+                    {
+                        $activityID = (int) $row[\'activity_id\'];
+                        $lastActivityID = $activityID;
+                        $notes = $row[\'notes\'];
+
+                        $cleanedNotes = preg_replace(
+                            "/<span\\b(?=[^>]*\\bstyle\\s*=\\s*([\\\"\\\'])[^\\\"\\\']*\\bcolor\\s*:\\s*#ff6c00\\b[^\\\"\\\']*\\1)[^>]*>(.*?)<\\/span>/is",
+                            "$2",
+                            $notes
+                        );
+
+                        if ($cleanedNotes === null || $cleanedNotes === $notes)
+                        {
+                            continue;
+                        }
+
+                        $db->query(
+                            "UPDATE activity
+                             SET notes = " . $db->makeQueryString($cleanedNotes) . "
+                             WHERE activity_id = " . $activityID
+                        );
+                    }
+                }
+            ',
 
         );
     }


### PR DESCRIPTION
## Summary

This PR stops persisting inline HTML markup for status change activity notes and cleans existing stored notes via a schema upgrade to remove previously persisted inline highlight markup.

## Motivation

Persisting presentation markup in the database mixes data and UI concerns, makes future styling changes harder and can cause inconsistent output across different views and exports. By storing plain text and removing legacy markup during upgrade, we keep activity notes clean and ensure consistent, maintainable rendering going forward.