### PR TITLE
feat: sort activity lists newest-first

### DIFF
--- a/lib/ActivityEntries.php
+++ b/lib/ActivityEntries.php
@@ -495,7 +495,8 @@ class ActivityEntries
             AND
                 activity.site_id = %s
             ORDER BY
-                dateCreatedSort DESC",
+                dateCreatedSort DESC,
+                activity.activity_id DESC",
             $this->_db->makeQueryInteger($dataItemID),
             $this->_db->makeQueryInteger($dataItemType),
             $this->_siteID
@@ -557,7 +558,8 @@ class ActivityEntries
             AND
                 contact.site_id = %s
             ORDER BY
-                dateCreatedSort DESC",
+                dateCreatedSort DESC,
+                activity.activity_id DESC",
             $this->_db->makeQueryInteger($companyID),
             $this->_db->makeQueryInteger(DATA_ITEM_CONTACT),
             $this->_db->makeQueryInteger($this->_siteID),

--- a/lib/ActivityEntries.php
+++ b/lib/ActivityEntries.php
@@ -495,7 +495,7 @@ class ActivityEntries
             AND
                 activity.site_id = %s
             ORDER BY
-                dateCreatedSort ASC",
+                dateCreatedSort DESC",
             $this->_db->makeQueryInteger($dataItemID),
             $this->_db->makeQueryInteger($dataItemType),
             $this->_siteID
@@ -557,7 +557,7 @@ class ActivityEntries
             AND
                 contact.site_id = %s
             ORDER BY
-                dateCreatedSort ASC",
+                dateCreatedSort DESC",
             $this->_db->makeQueryInteger($companyID),
             $this->_db->makeQueryInteger(DATA_ITEM_CONTACT),
             $this->_db->makeQueryInteger($this->_siteID),

--- a/modules/activity/dataGrids.php
+++ b/modules/activity/dataGrids.php
@@ -154,6 +154,12 @@ class ActivityDataGrid extends DataGrid
      */
     public function getSQL($selectSQL, $joinSQL, $whereSQL, $havingSQL, $orderSQL, $limitSQL, $distinct = '')
     {   
+        $orderSQLWithTieBreaker = $orderSQL;
+        if (preg_match('/^ORDER BY\s+dateCreatedSort\s+(ASC|DESC)\s*$/i', $orderSQLWithTieBreaker, $matches))
+        {
+            $orderSQLWithTieBreaker .= ', activityID ' . strtoupper($matches[1]);
+        }
+
         $sql = sprintf(
             "SELECT SQL_CALC_FOUND_ROWS %s
                 activity.activity_id AS activityID,
@@ -266,7 +272,7 @@ class ActivityDataGrid extends DataGrid
             $this->dateCriterion,
             (strlen($whereSQL) > 0) ? ' AND ' . $whereSQL : '',
             (strlen($havingSQL) > 0) ? ' HAVING ' . $havingSQL : '',
-            $orderSQL,
+            $orderSQLWithTieBreaker,
             $limitSQL
         );
 


### PR DESCRIPTION
## Summary

This PR changes activity list ordering to show the newest entries first across the application where activity lists are rendered via the shared activity retrieval logic.

It updates the core activity queries to sort by the existing created-date sort field in descending order and adds a deterministic tie-breaker by `activity_id` (descending) to ensure stable ordering when timestamps are identical.

Additionally, the Activities module DataGrid ordering is hardened by appending an `activityID` tie-breaker when sorting by `dateCreatedSort`.

## Motivation

Seeing the most recent activity first is the expected UX for activity feeds and improves day-to-day usability when reviewing recent interactions.

The deterministic `activity_id` tie-breaker avoids unstable ordering caused by equal timestamps, making list rendering predictable and preventing confusing “random” reordering between page loads or environments.