### PR TITLE
Fix Schema.php migrations 365–368 overwritten during PR689 conflict resolution

### DIFF
--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1328,7 +1328,53 @@ class CATSSchema
             '364' => '
                 UPDATE user SET password = md5(password) WHERE can_change_password=1;
             ',
-            '365' => 'PHP:
+            '365' => '
+                ALTER IGNORE TABLE `site`
+                ADD COLUMN `default_phone_country_code` varchar(8)
+                COLLATE utf8_unicode_ci NOT NULL DEFAULT \'+1\'
+                AFTER `date_format_ddmmyy`;
+            ',
+            '366' => '
+                ALTER IGNORE TABLE `candidate` ADD COLUMN `address2` TEXT COLLATE utf8_unicode_ci AFTER `address`;
+                ALTER IGNORE TABLE `contact` ADD COLUMN `address2` TEXT COLLATE utf8_unicode_ci AFTER `address`;
+                ALTER IGNORE TABLE `company` ADD COLUMN `address2` TEXT COLLATE utf8_unicode_ci AFTER `address`;
+            ',
+            '367' => '
+                UPDATE candidate
+                SET address = REPLACE(address, \'\\r\\n\', \'\\n\')
+                WHERE address LIKE \'%\\r\\n%\';
+                UPDATE candidate
+                SET
+                    address2 = TRIM(REPLACE(SUBSTRING(address, INSTR(address, \'\\n\') + 1), \'\\n\', \', \')),
+                    address  = TRIM(SUBSTRING_INDEX(address, \'\\n\', 1))
+                WHERE address IS NOT NULL
+                  AND INSTR(address, \'\\n\') > 0;
+
+                UPDATE contact
+                SET address = REPLACE(address, \'\\r\\n\', \'\\n\')
+                WHERE address LIKE \'%\\r\\n%\';
+                UPDATE contact
+                SET
+                    address2 = TRIM(REPLACE(SUBSTRING(address, INSTR(address, \'\\n\') + 1), \'\\n\', \', \')),
+                    address  = TRIM(SUBSTRING_INDEX(address, \'\\n\', 1))
+                WHERE address IS NOT NULL
+                  AND INSTR(address, \'\\n\') > 0;
+
+                UPDATE company
+                SET address = REPLACE(address, \'\\r\\n\', \'\\n\')
+                WHERE address LIKE \'%\\r\\n%\';
+                UPDATE company
+                SET
+                    address2 = TRIM(REPLACE(SUBSTRING(address, INSTR(address, \'\\n\') + 1), \'\\n\', \', \')),
+                    address  = TRIM(SUBSTRING_INDEX(address, \'\\n\', 1))
+                WHERE address IS NOT NULL
+                  AND INSTR(address, \'\\n\') > 0;
+            ',
+            '368' => '
+                ALTER TABLE `user`
+                    MODIFY `password` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT \'\';
+            ',
+            '369' => 'PHP:
                 $col = $db->getAssoc("SHOW COLUMNS FROM `site` LIKE \'last_viewed_day\'");
 
                 if (!empty($col))


### PR DESCRIPTION
Restores schema migration entries 365–368 in modules/install/Schema.php that were accidentally overwritten during manual merge conflict resolution for PR #689.

Preserves existing migration 369 (PHP: block) as-is.

No functional change beyond correcting the migration map so installs/upgrades apply the intended steps in order.

Context: follow-up fix after PR #689 merge issue; see #689 for background.

This is a fix-forward patch; it does not revert PR689, it corrects the schema migration table that got clobbered.