### PR TITLE
feat: rename Call activity to Not reached

### DIFF
--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -70,7 +70,7 @@ CREATE TABLE `activity_type` (
 
 /*Data for the table `activity_type` */
 
-insert  into `activity_type`(`activity_type_id`,`short_description`) values (100,'Call');
+insert  into `activity_type`(`activity_type_id`,`short_description`) values (100,'Not reached');
 insert  into `activity_type`(`activity_type_id`,`short_description`) values (200,'Email');
 insert  into `activity_type`(`activity_type_id`,`short_description`) values (300,'Meeting');
 insert  into `activity_type`(`activity_type_id`,`short_description`) values (400,'Other');

--- a/js/activity.js
+++ b/js/activity.js
@@ -41,10 +41,10 @@ function Activity_fillTypeSelect(selectList, selectedText)
 {
     var optionElements = new Array();
 
-    /* Call option. */
+    /* Not reached option. */
     optionElements[0] = document.createElement("option");
     optionElements[0].value = ACTIVITY_CALL;
-    optionElements[0].appendChild(document.createTextNode("Call"));
+    optionElements[0].appendChild(document.createTextNode("Not reached"));
 
     /* Call (Talked) option. */
     optionElements[1] = document.createElement("option");
@@ -79,7 +79,7 @@ function Activity_fillTypeSelect(selectList, selectedText)
     /* Select the correct option. */
     if (selectedText)
     {
-        if (selectedText == "Call")
+        if (selectedText == "Not reached")
         {
             optionElements[0].setAttribute("selected", "selected");
         }

--- a/modules/candidates/AddActivityChangeStatusModal.tpl
+++ b/modules/candidates/AddActivityChangeStatusModal.tpl
@@ -123,7 +123,7 @@
                         <span id="addActivitySpanA">Activity Type</span><br />
                         <select id="activityTypeID" name="activityTypeID" class="inputbox" style="width: 150px; margin-bottom: 4px;">
                             <option selected="selected" value="">-- Select --</option>
-                            <option value="<?php echo(ACTIVITY_CALL); ?>">Call</option>
+                            <option value="<?php echo(ACTIVITY_CALL); ?>">Not reached</option>
                             <option value="<?php echo(ACTIVITY_CALL_TALKED); ?>">Call (Talked)</option>
                             <option value="<?php echo(ACTIVITY_CALL_LVM); ?>">Call (LVM)</option>
                             <option value="<?php echo(ACTIVITY_CALL_MISSED); ?>">Call (Missed)</option>

--- a/modules/contacts/AddActivityScheduleEventModal.tpl
+++ b/modules/contacts/AddActivityScheduleEventModal.tpl
@@ -42,7 +42,7 @@
                         <span id="addActivitySpanA">Activity Type</span><br />
                         <select id="activityTypeID" name="activityTypeID" class="inputbox" style="width: 150px; margin-bottom: 4px;">
                             <option selected="selected" value="">-- Select --</option>
-                            <option value="<?php echo(ACTIVITY_CALL); ?>">Call</option>
+                            <option value="<?php echo(ACTIVITY_CALL); ?>">Not reached</option>
                             <option value="<?php echo(ACTIVITY_CALL_TALKED); ?>">Call (Talked)</option>
                             <option value="<?php echo(ACTIVITY_CALL_LVM); ?>">Call (LVM)</option>
                             <option value="<?php echo(ACTIVITY_CALL_MISSED); ?>">Call (Missed)</option>

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1442,6 +1442,11 @@ class CATSSchema
                     $db->query("ALTER TABLE `".$row[\'table_name\']."` ENGINE=InnoDB");
                 }
             ',
+            '376' => '
+                UPDATE activity_type
+                SET short_description = \'Not reached\'
+                WHERE activity_type_id = 100;
+            ',
 
         );
     }

--- a/test/features/activities.feature
+++ b/test/features/activities.feature
@@ -13,7 +13,7 @@ Feature: Activities
     And I follow "Log an Activity"
     And I wait for the activity note box to appear
     And I switch to the iframe "popupInner"
-    And I select "Call" from "activityTypeID"
+    And I select "Not reached" from "activityTypeID"
     And fill in "activityNote" with "Call Gandalf"
     And press "Save"
     And press "Close"


### PR DESCRIPTION
## Summary

This PR renames the existing `Call` activity to `Not reached`.

The change updates the default schema for new installations, adjusts the relevant UI code paths that still used the `Call` label directly and adds a database migration so existing installations are updated as well.

The related activity types `Call (Talked)`, `Call (LVM)` and `Call (Missed)` remain unchanged.

## Motivation

The activity labels `Call` and `Call (Talked)` are too close to each other and can be confusing in daily use.

Using `Not reached` makes the distinction clearer, because it separates unsuccessful contact attempts from successful calls more explicitly.

This improves the activity selection and makes the intent of the existing activity type easier to understand without changing its underlying ID or behavior.