### PR TITLE
fix: correct candidate re-apply update mapping and guard empty ownership emails

### DIFF
--- a/lib/Candidates.php
+++ b/lib/Candidates.php
@@ -345,7 +345,7 @@ class Candidates
             return false;
         }
 
-        if (!empty($emailAddress))
+        if (!empty($emailAddress) && !empty($email))
         {
             /* Send e-mail notification. */
             //FIXME: Make subject configurable.

--- a/modules/careers/CareersUI.php
+++ b/modules/careers/CareersUI.php
@@ -1590,8 +1590,8 @@ class CareersUI extends UserInterface
                 $candidateID, $candidate['isActive'] ? true : false, $firstName, $middleName,
                 $lastName, $email, $email2, $phoneHome, $phoneCell, $phone, $address, $address2, $city,
                 $state, $zip, $source, $keySkills, '', $employer, '', '', '', $candidate['notes'],
-                '', $bestTimeToCall, $automatedUser['userID'], $automatedUser['userID'], $gender,
-                $race, $veteran, $disability
+                '', $bestTimeToCall, $automatedUser['userID'], $candidate['isHot'] ? true : false,
+                $email, $email, $gender, $race, $veteran, $disability
             );
 
             /* Update extra feilds */

--- a/modules/careers/CareersUI.php
+++ b/modules/careers/CareersUI.php
@@ -1590,8 +1590,8 @@ class CareersUI extends UserInterface
                 $candidateID, $candidate['isActive'] ? true : false, $firstName, $middleName,
                 $lastName, $email, $email2, $phoneHome, $phoneCell, $phone, $address, $address2, $city,
                 $state, $zip, $source, $keySkills, '', $employer, '', '', '', $candidate['notes'],
-                '', $bestTimeToCall, $automatedUser['userID'], $candidate['isHot'] ? true : false,
-                $email, $email, $gender, $race, $veteran, $disability
+                '', $bestTimeToCall, $automatedUser['userID'], false,
+                '', '', $gender, $race, $veteran, $disability
             );
 
             /* Update extra feilds */


### PR DESCRIPTION
Fixes #725

This PR corrects the misaligned `Candidates::update()` call in the careers re-apply flow.

It also adds a small safeguard in `lib/Candidates.php` so candidate ownership notifications are only sent when both the recipient and email body are non-empty.
