### PR TITLE
fix: render line breaks in activity notes

### DIFF
--- a/ajax/getPipelineDetails.php
+++ b/ajax/getPipelineDetails.php
@@ -77,7 +77,7 @@ else
              $activity['enteredByLastName'],
              ')</td>';
         echo '<td style="padding-right: 6px; width: 625px;">',
-             $activity['notes'],
+             nl2br($activity['notes']),
              '<br /></td>';
         echo '</tr>';
     }

--- a/modules/activity/Search.tpl
+++ b/modules/activity/Search.tpl
@@ -77,7 +77,7 @@
                             </td>
 
                             <td align="left" valign="top" >
-                                <?php echo($activityData['notes']); ?>
+                                <?php echo(nl2br($activityData['notes'])); ?>
                             </td>
 
                             <td align="left" valign="top">

--- a/modules/activity/dataGrids.php
+++ b/modules/activity/dataGrids.php
@@ -128,7 +128,7 @@ class ActivityDataGrid extends DataGrid
                                      'alphaNavigation' => true,
                                      'filter'          => 'activity_type.short_description'),  
                                      
-             'Notes' =>      array('pagerRender'    => 'return $rsData[\'notes\'];', 
+             'Notes' =>      array('pagerRender'    => 'return nl2br($rsData[\'notes\']);', 
                                      'sortableColumn'  => 'notes',
                                      'pagerWidth'      => 240,
                                      'pagerOptional'   => true,

--- a/modules/candidates/Show.tpl
+++ b/modules/candidates/Show.tpl
@@ -640,7 +640,7 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                         <td align="left" valign="top" id="activityType<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['regarding']) ?></td>
-                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo($activityData['notes']); ?></td>
+                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br($activityData['notes'])); ?></td>
 <?php if (!$this->isPopup): ?>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('candidates.edit') >= ACCESS_LEVEL_EDIT): ?>

--- a/modules/companies/Show.tpl
+++ b/modules/companies/Show.tpl
@@ -445,7 +445,7 @@ use OpenCATS\UI\QuickActionMenu;
                         </td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']); ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['regarding']); ?></td>
-                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['notes']); ?></td>
+                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br(htmlspecialchars($activityData['notes'], ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING))); ?></td>
                         <td align="center">
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>
                                 <a href="#" id="editActivity<?php echo($activityData['activityID']); ?>" onclick="Activity_editEntry(<?php echo($activityData['activityID']); ?>, <?php echo($activityData['contactID']); ?>, <?php echo(DATA_ITEM_CONTACT); ?>, '<?php echo($this->sessionCookie); ?>'); return false;">

--- a/modules/contacts/Show.tpl
+++ b/modules/contacts/Show.tpl
@@ -289,7 +289,7 @@ use OpenCATS\UI\QuickActionMenu;
                         <td align="left" valign="top" id="activityType<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['regarding']) ?></td>
-                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['notes']) ?></td>
+                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br(htmlspecialchars($activityData['notes'], ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING))); ?></td>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>
                                 <a href="#" id="editActivity<?php echo($activityData['activityID']); ?>" onclick="Activity_editEntry(<?php echo($activityData['activityID']); ?>, <?php echo($this->contactID); ?>, <?php echo(DATA_ITEM_CONTACT); ?>, '<?php echo($this->sessionCookie); ?>'); return false;">


### PR DESCRIPTION
This PR fixes activity note rendering so that stored line breaks are displayed consistently across activity-related list and detail views.

Previously, multi-line notes were shown as a single block of text in several places, which made longer activity entries harder to read.