### PR TITLE
chore: remove unused legacy settings from config.php and test/config.php

### DIFF
--- a/config.php
+++ b/config.php
@@ -104,9 +104,7 @@ define('SPHINX_INDEX', 'cats catsdelta');
 
 
 /* Pager settings. These are the number of results per page. */
-define('CONTACTS_PER_PAGE',      15);
 define('CANDIDATES_PER_PAGE',    15);
-define('CLIENTS_PER_PAGE',       15);
 define('LOGIN_ENTRIES_PER_PAGE', 15);
 
 /* Maximum number of characters of the owner/recruiter users' last names
@@ -164,14 +162,6 @@ define('CAREERS_OWNERAPPLY_SUBJECT', 'CATS - A Candidate Has Applied to Your Job
  * job order.
  */
 define('CANDIDATE_STATUSCHANGE_SUBJECT', 'Job Application Status Change');
-
-/* Password request settings.
- *
- * In FORGOT_PASSWORD_FROM, %s is the placeholder for the password.
- */
-define('FORGOT_PASSWORD_FROM_NAME', 'CATS');
-define('FORGOT_PASSWORD_SUBJECT',   'CATS - Password Retrieval Request');
-define('FORGOT_PASSWORD_BODY',      'You recently requested that your OpenCATS: Applicant Tracking System password be sent to you. Your current password is %s.');
 
 /* Is this a demo site? */
 define('ENABLE_DEMO_MODE', false);

--- a/test/config.php
+++ b/test/config.php
@@ -105,9 +105,7 @@ define('SPHINX_INDEX', 'cats catsdelta');
 
 
 /* Pager settings. These are the number of results per page. */
-define('CONTACTS_PER_PAGE',      15);
 define('CANDIDATES_PER_PAGE',    15);
-define('CLIENTS_PER_PAGE',       15);
 define('LOGIN_ENTRIES_PER_PAGE', 15);
 
 /* Maximum number of characters of the owner/recruiter users' last names
@@ -165,14 +163,6 @@ define('CAREERS_OWNERAPPLY_SUBJECT', 'CATS - A Candidate Has Applied to Your Job
  * job order.
  */
 define('CANDIDATE_STATUSCHANGE_SUBJECT', 'Job Application Status Change');
-
-/* Password request settings.
- *
- * In FORGOT_PASSWORD_FROM, %s is the placeholder for the password.
- */
-define('FORGOT_PASSWORD_FROM_NAME', 'CATS');
-define('FORGOT_PASSWORD_SUBJECT',   'CATS - Password Retrieval Request');
-define('FORGOT_PASSWORD_BODY',      'You recently requested that your OpenCATS: Applicant Tracking System password be sent to you. Your current password is %s.');
 
 /* Is this a demo site? */
 define('ENABLE_DEMO_MODE', false);


### PR DESCRIPTION
This PR removes unused legacy settings from `config.php` and `test/config.php`.

The cleanup is intentionally minimal and only removes configuration entries that are no longer used in the current codebase. In particular, this includes `CONTACTS_PER_PAGE`, `CLIENTS_PER_PAGE`, `FORGOT_PASSWORD_FROM_NAME`, `FORGOT_PASSWORD_SUBJECT`, and `FORGOT_PASSWORD_BODY`.
