### PR TITLE
feat: make state optional for job orders

### DIFF
--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -801,7 +801,7 @@ CREATE TABLE `joborder` (
   `is_hot` int(1) NOT NULL DEFAULT '0',
   `openings` int(11) DEFAULT NULL,
   `city` varchar(64) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `state` varchar(64) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `state` varchar(64) COLLATE utf8_unicode_ci DEFAULT NULL,
   `start_date` datetime DEFAULT NULL,
   `date_created` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   `date_modified` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',

--- a/lib/DatabaseConnection.php
+++ b/lib/DatabaseConnection.php
@@ -507,9 +507,9 @@ class DatabaseConnection
      */
     public function makeQueryStringOrNULL($string)
     {
-        $string = trim($string);
+        $string = trim((string) $string);
 
-        if (empty($string))
+        if ($string === '')
         {
             return 'NULL';
         }

--- a/lib/JobOrders.php
+++ b/lib/JobOrders.php
@@ -221,7 +221,7 @@ class JobOrders
             $this->_db->makeQueryString($status),
             $this->_db->makeQueryString($salary),
             $this->_db->makeQueryString($city),
-            $this->_db->makeQueryString($state),
+            $this->_db->makeQueryStringOrNULL($state),
             $this->_db->makeQueryInteger($departmentID),
             $this->_db->makeQueryInteger($recruiter),
             $this->_db->makeQueryInteger($owner),

--- a/lib/StringUtility.php
+++ b/lib/StringUtility.php
@@ -605,8 +605,8 @@ class StringUtility
      */
     public static function makeCityStateString($city, $state)
     {
-        $city  = trim($city);
-        $state = trim($state);
+        $city  = trim((string) $city);
+        $state = trim((string) $state);
 
         if (!empty($city))
         {

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1447,6 +1447,10 @@ class CATSSchema
                 SET short_description = \'Not reached\'
                 WHERE activity_type_id = 100;
             ',
+            '377' => '
+                ALTER TABLE `joborder`
+                CHANGE `state` `state` VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+            ',
 
         );
     }

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1494,6 +1494,10 @@ class CATSSchema
                     }
                 }
             ',
+            '378' => '
+                ALTER TABLE `joborder`
+                CHANGE `state` `state` VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+            ',
 
         );
     }

--- a/modules/joborders/Add.tpl
+++ b/modules/joborders/Add.tpl
@@ -167,9 +167,9 @@
                             </td>
                             <td class="tdData">
                                 <?php if ($this->selectedCompanyID !== false): ?>
-                                    <input type="text" tabindex="5" class="inputbox" id="state" name="state" value="<?php $this->_($this->selectedCompanyLocation['state']); ?>" style="width: 150px;" />&nbsp;*
+                                    <input type="text" tabindex="5" class="inputbox" id="state" name="state" value="<?php $this->_($this->selectedCompanyLocation['state']); ?>" style="width: 150px;" />
                                 <?php else: ?>
-                                    <input type="text" tabindex="5" class="inputbox" id="state" name="state" style="width: 150px;" />&nbsp;*
+                                    <input type="text" tabindex="5" class="inputbox" id="state" name="state" style="width: 150px;" />
                                 <?php endif; ?>
                             </td>
 

--- a/modules/joborders/Edit.tpl
+++ b/modules/joborders/Edit.tpl
@@ -178,7 +178,7 @@
                             <label id="stateLabel" for="state">State:</label>
                         </td>
                         <td class="tdData">
-                            <input type="text" tabindex="5" class="inputbox" id="state" name="state" value="<?php $this->_($this->data['state']); ?>" style="width: 150px;" />&nbsp;*
+                            <input type="text" tabindex="5" class="inputbox" id="state" name="state" value="<?php $this->_($this->data['state']); ?>" style="width: 150px;" />
                         </td>
 
                         <td class="tdVertical">

--- a/modules/joborders/JobOrdersUI.php
+++ b/modules/joborders/JobOrdersUI.php
@@ -808,7 +808,7 @@ class JobOrdersUI extends UserInterface
         $notes       = $this->getTrimmedInput('notes', $_POST);
 
         /* Bail out if any of the required fields are empty. */
-        if (empty($title) || empty($type) || empty($city) || empty($state))
+        if (empty($title) || empty($type) || empty($city))
         {
             CommonErrors::fatal(COMMONERROR_MISSINGFIELDS, $this, 'Required fields are missing.');
         }
@@ -1146,7 +1146,7 @@ class JobOrdersUI extends UserInterface
         $notes       = $this->getTrimmedInput('notes', $_POST);
 
         /* Bail out if any of the required fields are empty. */
-        if (empty($title) || empty($type) || empty($city) || empty($state))
+        if (empty($title) || empty($type) || empty($city))
         {
             CommonErrors::fatal(COMMONERROR_MISSINGFIELDS, $this, 'Required fields are missing.');
         }

--- a/modules/joborders/JobOrdersUI.php
+++ b/modules/joborders/JobOrdersUI.php
@@ -825,7 +825,7 @@ class JobOrdersUI extends UserInterface
         $notes       = $this->getTrimmedInput('notes', $_POST);
 
         /* Bail out if any of the required fields are empty. */
-        if (empty($title) || empty($type) || empty($city) || empty($state))
+        if (empty($title) || empty($type) || empty($city))
         {
             CommonErrors::fatal(COMMONERROR_MISSINGFIELDS, $this, 'Required fields are missing.');
         }
@@ -1163,7 +1163,7 @@ class JobOrdersUI extends UserInterface
         $notes       = $this->getTrimmedInput('notes', $_POST);
 
         /* Bail out if any of the required fields are empty. */
-        if (empty($title) || empty($type) || empty($city) || empty($state))
+        if (empty($title) || empty($type) || empty($city))
         {
             CommonErrors::fatal(COMMONERROR_MISSINGFIELDS, $this, 'Required fields are missing.');
         }

--- a/modules/joborders/validator.js
+++ b/modules/joborders/validator.js
@@ -16,7 +16,6 @@ function checkAddForm(form)
     errorMessage += checkCompany();
     errorMessage += checkRecruiter();
     errorMessage += checkCity();
-    errorMessage += checkState();
     errorMessage += checkOpenings();
 
     if (errorMessage != "")
@@ -36,7 +35,6 @@ function checkEditForm(form)
     errorMessage += checkCompany();
     errorMessage += checkRecruiter();
     errorMessage += checkCity();
-    errorMessage += checkState();
     errorMessage += checkOpenings();
     errorMessage += checkOpeningsAvailable();
     errorMessage += checkOwner();
@@ -124,26 +122,6 @@ function checkCity()
     if (fieldValue == "")
     {
         errorMessage = "    - You must enter a city.\n";
-
-        fieldLabel.style.color = "#ff0000";
-    }
-    else
-    {
-        fieldLabel.style.color = "#000";
-    }
-
-    return errorMessage;
-}
-
-function checkState()
-{
-    var errorMessage = "";
-
-    fieldValue = document.getElementById("state").value;
-    fieldLabel = document.getElementById("stateLabel");
-    if (fieldValue == "")
-    {
-        errorMessage = "    - You must enter a state.\n";
 
         fieldLabel.style.color = "#ff0000";
     }
@@ -336,6 +314,3 @@ function checkFilename()
 
     return errorMessage;
 }
-
-
-

--- a/src/OpenCATS/Entity/JobOrderRepository.php
+++ b/src/OpenCATS/Entity/JobOrderRepository.php
@@ -91,7 +91,7 @@ class JobOrderRepository
             $this->databaseConnection->makeQueryInteger($jobOrder->getAvailableOpenings()),
             $this->databaseConnection->makeQueryString($jobOrder->getSalary()),
             $this->databaseConnection->makeQueryString($jobOrder->getCity()),
-            $this->databaseConnection->makeQueryString($jobOrder->getState()),
+            $this->databaseConnection->makeQueryStringOrNULL($jobOrder->getState()),
             $this->databaseConnection->makeQueryInteger($jobOrder->getDepartmentId()),
             $this->databaseConnection->makeQueryStringOrNULL($jobOrder->getStartDate()),
             $this->databaseConnection->makeQueryInteger($jobOrder->getEnteredBy()),

--- a/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
+++ b/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
@@ -63,10 +63,12 @@ class DatabaseConnectionTest extends DatabaseTestCase
             array('te\'st',  "'te\\'st'"),
             array('\'; DELETE FROM test_table; SELECT \'',  "'\'; DELETE FROM test_table; SELECT \''"),
             array('te\'s`t',  "'te\\'s`t'"),
+            array('0', "'0'"),
             array('    ',  'NULL'),
             array(' ',  'NULL'),
             array('	 		',  'NULL'),
-            array('',  'NULL')
+            array('',  'NULL'),
+            array(null, 'NULL')
         );
 
         foreach ($strings as $key => $value)

--- a/src/OpenCATS/Tests/UnitTests/StringUtilityTest.php
+++ b/src/OpenCATS/Tests/UnitTests/StringUtilityTest.php
@@ -556,6 +556,44 @@ class StringUtilityTest extends TestCase
             );
     }
 
+    function testMakeCityStateString()
+    {
+        $this->assertSame(
+            'Chicago, IL',
+            StringUtility::makeCityStateString('Chicago', 'IL')
+            );
+
+        $this->assertSame(
+            'Chicago',
+            StringUtility::makeCityStateString('Chicago', '')
+            );
+
+        $this->assertSame(
+            'IL',
+            StringUtility::makeCityStateString('', 'IL')
+            );
+
+        $this->assertSame(
+            '',
+            StringUtility::makeCityStateString('', '')
+            );
+
+        $this->assertSame(
+            'Chicago',
+            StringUtility::makeCityStateString('Chicago', null)
+            );
+
+        $this->assertSame(
+            'IL',
+            StringUtility::makeCityStateString(null, 'IL')
+            );
+
+        $this->assertSame(
+            '',
+            StringUtility::makeCityStateString(null, null)
+            );
+    }
+
     /* Tests for escapeSingleQuotes(). */
     function testEscapeSingleQuotes()
     {

--- a/test/features/job-orders.feature
+++ b/test/features/job-orders.feature
@@ -49,7 +49,6 @@ Feature: Job Orders
     Then I should see "Form Error" in alert popup
     And I should see "You must select a company" in alert popup
     And I should see "You must enter a city" in alert popup
-    And I should see "You must enter a state" in alert popup
     And I confirm the popup
     
   @javascript


### PR DESCRIPTION
## Summary

This PR makes the `state` field optional when creating and editing job orders.

This change removes the required marker from the job order add and edit forms, drops the client-side validation that forced a state value and updates the server-side validation so job orders can be saved without a state.

## Motivation

OpenCATS is being improved for better internationalization.

Requiring a state works for some countries, but it does not fit well everywhere. In many countries, a state or equivalent administrative region is uncommon, not normally used in job postings or not expected as part of a business address. Making this field optional allows job orders to better reflect local conventions and avoids unnecessary validation failures for users outside state-centric address formats.