### PR TITLE
fix: quote reserved YAML scalars in test/behat.yml

### DIFF
--- a/test/behat.yml
+++ b/test/behat.yml
@@ -1,17 +1,17 @@
 default:
     suites:
         default:
-            paths: [ %paths.base%/features ]
+            paths: [ "%paths.base%/features" ]
             contexts:
                 - FeatureContext
             filters:
-                tags: @core 
+                tags: "@core"
         security:
-            paths: [ %paths.base%/features ]
+            paths: [ "%paths.base%/features" ]
             contexts:
                 - SecurityContext
             filters:
-                tags: @security 
+                tags: "@security"
     extensions:
         Behat\MinkExtension:
             base_url: http://opencats


### PR DESCRIPTION
This updates `test/behat.yml` to quote YAML scalar values that start with reserved indicators.

The affected values are the `%paths.base%/features` placeholders in `paths` and the `@core` / `@security` values in `tags`.

Unquoted values starting with reserved YAML indicators such as `%` and `@` can cause parsing issues depending on the YAML parser and environment.

Quoting these values makes the configuration more robust and avoids compatibility issues without changing the intended behavior of the Behat suites.