### PR TITLE
fix: add file-based cache busting for JavaScript and stylesheet assets

### DIFF
--- a/installtest.php
+++ b/installtest.php
@@ -33,6 +33,24 @@ include_once('./config.php');
 include_once(LEGACY_ROOT . '/constants.php');
 include_once(LEGACY_ROOT . '/lib/InstallationTests.php');
 
+/* Version check before including TemplateUtility for asset URL versioning. */
+$phpVersion = phpversion();
+$phpVersionParts = explode('.', $phpVersion);
+if ($phpVersionParts[0] >= 5)
+{
+    include_once(LEGACY_ROOT . '/lib/TemplateUtility.php');
+}
+else
+{
+    $php4 = true;
+}
+
+$mainCSSURL = 'main.css';
+if (!isset($php4))
+{
+    $mainCSSURL = call_user_func(array('TemplateUtility', 'getVersionedAssetURL'), $mainCSSURL);
+}
+
 
 define('REQUIRED_SCHEMA_VERSION', '1200');
 
@@ -45,7 +63,7 @@ header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 <html>
     <head>
         <title>CATS - Installation Test Script</title>
-        <style type="text/css" media="all">@import "main.css";</style>
+        <style type="text/css" media="all">@import "<?php echo $mainCSSURL; ?>";</style>
         <style type="text/css" media="all">
             table.test_output
             {

--- a/installwizard.php
+++ b/installwizard.php
@@ -19,14 +19,26 @@
     {
         $php4 = true;
     }
+
+    $installLibURL = 'js/lib.js';
+    $installScriptURL = 'js/install.js';
+    $subModalScriptURL = 'js/submodal/subModal.js';
+    $installCSSURL = 'modules/install/install.css';
+    if (!isset($php4))
+    {
+        $installLibURL = call_user_func(array('TemplateUtility', 'getVersionedAssetURL'), $installLibURL);
+        $installScriptURL = call_user_func(array('TemplateUtility', 'getVersionedAssetURL'), $installScriptURL);
+        $subModalScriptURL = call_user_func(array('TemplateUtility', 'getVersionedAssetURL'), $subModalScriptURL);
+        $installCSSURL = call_user_func(array('TemplateUtility', 'getVersionedAssetURL'), $installCSSURL);
+    }
 ?>
 <html>
     <head>
         <title>OpenCATS - Installation Wizard Script</title>
-        <script type="text/javascript" src="js/lib.js"></script>
-        <script type="text/javascript" src="js/install.js"></script>
-        <script type="text/javascript" src="js/submodal/subModal.js"></script>
-        <style type="text/css" media="all">@import "modules/install/install.css";</style>
+        <script type="text/javascript" src="<?php echo $installLibURL; ?>"></script>
+        <script type="text/javascript" src="<?php echo $installScriptURL; ?>"></script>
+        <script type="text/javascript" src="<?php echo $subModalScriptURL; ?>"></script>
+        <style type="text/css" media="all">@import "<?php echo $installCSSURL; ?>";</style>
     </head>
 
     <body>

--- a/js/submodal/loading.html
+++ b/js/submodal/loading.html
@@ -4,6 +4,7 @@
     <head>
         <title>Loading...</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <!-- This file is loaded as static HTML and does not go through the normal PHP template pipeline, so its stylesheet path is not versioned by the shared asset helper. -->
         <style type="text/css" media="all">@import "../../main.css";</style>
     </head>
 

--- a/lib/Display.php
+++ b/lib/Display.php
@@ -108,7 +108,10 @@ class Display
         $sheet = $this->_profileLib->getProfileStylesheet();
         if ($profileStylesheet === false || strcmp($profileStylesheet, $sheet))
         {
-            echo sprintf('<link rel="stylesheet" type="text/css" href="%s" />', $sheet);
+            echo sprintf(
+                '<link rel="stylesheet" type="text/css" href="%s" />',
+                TemplateUtility::getVersionedAssetURL($sheet)
+            );
             $profileStylesheet = $sheet;
         }
 

--- a/lib/TemplateUtility.php
+++ b/lib/TemplateUtility.php
@@ -1171,6 +1171,76 @@ class TemplateUtility
     }
 
     /**
+     * Returns an asset URL with a file-based version query parameter.
+     *
+     * @param string Relative asset path
+     * @return string
+     */
+    public static function getVersionedAssetURL($assetPath)
+    {
+        $assetPath = (string) $assetPath;
+        if ($assetPath == '')
+        {
+            return $assetPath;
+        }
+
+        $parsedURL = parse_url($assetPath);
+        if ($parsedURL === false || isset($parsedURL['scheme']) || isset($parsedURL['host']))
+        {
+            return $assetPath;
+        }
+
+        $path = isset($parsedURL['path']) ? $parsedURL['path'] : '';
+        if ($path == '')
+        {
+            return $assetPath;
+        }
+
+        $legacyRootPath = realpath(LEGACY_ROOT);
+        if ($legacyRootPath === false)
+        {
+            return $assetPath;
+        }
+
+        $normalizedPath = ltrim(str_replace('\\', '/', $path), '/');
+        if ($normalizedPath == '')
+        {
+            return $assetPath;
+        }
+
+        $assetFilePath = realpath(
+            $legacyRootPath . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $normalizedPath)
+        );
+        if ($assetFilePath === false)
+        {
+            return $assetPath;
+        }
+
+        $legacyRootPrefix = rtrim($legacyRootPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        if ($assetFilePath !== $legacyRootPath && strpos($assetFilePath, $legacyRootPrefix) !== 0)
+        {
+            return $assetPath;
+        }
+
+        $fileMTime = @filemtime($assetFilePath);
+        if ($fileMTime === false)
+        {
+            return $assetPath;
+        }
+
+        $queryString = isset($parsedURL['query']) ? $parsedURL['query'] . '&' : '';
+        $queryString .= 'v=' . (int) $fileMTime;
+
+        $versionedAssetURL = $path . '?' . $queryString;
+        if (isset($parsedURL['fragment']))
+        {
+            $versionedAssetURL .= '#' . $parsedURL['fragment'];
+        }
+
+        return $versionedAssetURL;
+    }
+
+    /**
      * Prints template header HTML.
      *
      * @param string page title

--- a/lib/TemplateUtility.php
+++ b/lib/TemplateUtility.php
@@ -1278,11 +1278,22 @@ class TemplateUtility
              CATSUtility::getIndexName(), '?m=rss" />', "\n";
 
         /* Core JS files */
-        echo '<script type="text/javascript" src="js/lib.js'.$javascriptAntiCache.'"></script>', "\n";
-        echo '<script type="text/javascript" src="js/quickAction.js'.$javascriptAntiCache.'"></script>', "\n";
-        echo '<script type="text/javascript" src="js/calendarDateInput.js'.$javascriptAntiCache.'"></script>', "\n";
-        echo '<script type="text/javascript" src="js/submodal/subModal.js'.$javascriptAntiCache.'"></script>', "\n";
-        echo '<script type="text/javascript" src="js/jquery-1.3.2.min.js'.$javascriptAntiCache.'"></script>', "\n";
+        $coreJavaScriptFiles = array(
+            'js/lib.js',
+            'js/quickAction.js',
+            'js/calendarDateInput.js',
+            'js/submodal/subModal.js',
+            'js/jquery-1.3.2.min.js'
+        );
+        foreach ($coreJavaScriptFiles as $coreJavaScriptFile)
+        {
+            $versionedFilename = self::getVersionedAssetURL($coreJavaScriptFile);
+            if ($versionedFilename === $coreJavaScriptFile)
+            {
+                $versionedFilename .= $javascriptAntiCache;
+            }
+            echo '<script type="text/javascript" src="', $versionedFilename, '"></script>', "\n";
+        }
         echo '<script type="text/javascript">CATSIndexName = ', json_encode((string) CATSUtility::getIndexName(), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT), ';</script>', "\n";
         if (isset($_SESSION['CATS']) && $_SESSION['CATS']->isLoggedIn())
         {
@@ -1354,22 +1365,35 @@ class TemplateUtility
 
         foreach ($headIncludes as $key => $filename)
         {
-            $extension = substr($filename, strrpos($filename, '.') + 1);
+            $path = parse_url($filename, PHP_URL_PATH);
+            if ($path === false || $path === null)
+            {
+                $path = $filename;
+            }
+            $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
-            $filename .= $javascriptAntiCache;
+            $versionedFilename = self::getVersionedAssetURL($filename);
+            if ($versionedFilename === $filename)
+            {
+                $versionedFilename .= $javascriptAntiCache;
+            }
 
             if ($extension == 'js')
             {
-                echo '<script type="text/javascript" src="', $filename, '"></script>', "\n";
+                echo '<script type="text/javascript" src="', $versionedFilename, '"></script>', "\n";
             }
             else if ($extension == 'css')
             {
-                echo '<style type="text/css" media="all">@import "', $filename, '";</style>', "\n";
+                echo '<style type="text/css" media="all">@import "', $versionedFilename, '";</style>', "\n";
             }
         }
 
-        echo '<!--[if IE]><link rel="stylesheet" type="text/css" href="ie.css" /><![endif]-->', "\n";
-        echo '<![if !IE]><link rel="stylesheet" type="text/css" href="not-ie.css" /><![endif]>', "\n";
+        echo '<!--[if IE]><link rel="stylesheet" type="text/css" href="',
+             self::getVersionedAssetURL('ie.css'),
+             '" /><![endif]-->', "\n";
+        echo '<![if !IE]><link rel="stylesheet" type="text/css" href="',
+             self::getVersionedAssetURL('not-ie.css'),
+             '" /><![endif]>', "\n";
         echo '</head>', "\n\n";
     }
 

--- a/lib/TemplateUtility.php
+++ b/lib/TemplateUtility.php
@@ -1256,16 +1256,6 @@ class TemplateUtility
 
         $siteID = $_SESSION['CATS']->getSiteID();
 
-        /* This prevents caching problems when SVN updates are preformed. */
-        if ($_SESSION['CATS']->getCachedBuild() > 0)
-        {
-            $javascriptAntiCache = '?b=' . $_SESSION['CATS']->getCachedBuild();
-        }
-        else
-        {
-            $javascriptAntiCache = '?v=' . CATSUtility::getVersionAsInteger();
-        }
-
         echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"', "\n";
         echo '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">', "\n";
         echo '<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">', "\n";
@@ -1288,10 +1278,6 @@ class TemplateUtility
         foreach ($coreJavaScriptFiles as $coreJavaScriptFile)
         {
             $versionedFilename = self::getVersionedAssetURL($coreJavaScriptFile);
-            if ($versionedFilename === $coreJavaScriptFile)
-            {
-                $versionedFilename .= $javascriptAntiCache;
-            }
             echo '<script type="text/javascript" src="', $versionedFilename, '"></script>', "\n";
         }
         echo '<script type="text/javascript">CATSIndexName = ', json_encode((string) CATSUtility::getIndexName(), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT), ';</script>', "\n";
@@ -1373,10 +1359,6 @@ class TemplateUtility
             $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
             $versionedFilename = self::getVersionedAssetURL($filename);
-            if ($versionedFilename === $filename)
-            {
-                $versionedFilename .= $javascriptAntiCache;
-            }
 
             if ($extension == 'js')
             {

--- a/modules/careers/Blank.tpl
+++ b/modules/careers/Blank.tpl
@@ -4,16 +4,16 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=<?php echo(HTML_ENCODING); ?>" />
         <title><?php $this->_($this->siteName); ?> - Careers</title>
-            <script type="text/javascript" src="../js/careerPortalApply.js"></script>
+            <script type="text/javascript" src="<?php echo '../' . TemplateUtility::getVersionedAssetURL('js/careerPortalApply.js'); ?>"></script>
         <?php global $careerPage; if (isset($careerPage) && $careerPage == true): ?>
-            <script type="text/javascript" src="../js/lib.js"></script>
-            <script type="text/javascript" src="../js/sorttable.js"></script>
-            <script type="text/javascript" src="../js/calendarDateInput.js"></script>
+            <script type="text/javascript" src="<?php echo '../' . TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo '../' . TemplateUtility::getVersionedAssetURL('js/sorttable.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo '../' . TemplateUtility::getVersionedAssetURL('js/calendarDateInput.js'); ?>"></script>
         <?php else: ?>
-            <script type="text/javascript" src="js/lib.js"></script>
-            <script type="text/javascript" src="js/sorttable.js"></script>
-            <script type="text/javascript" src="js/calendarDateInput.js"></script>
-			<script type="text/javascript" src="js/careersPage.js"></script>
+            <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/sorttable.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/calendarDateInput.js'); ?>"></script>
+			<script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/careersPage.js'); ?>"></script>
         <?php endif; ?>
         <style type="text/css" media="all">
             <?php echo($this->template['CSS']); ?>

--- a/modules/careers/Blank2.tpl
+++ b/modules/careers/Blank2.tpl
@@ -5,11 +5,11 @@
         <meta http-equiv="Content-Type" content="text/html; charset=<?php echo(HTML_ENCODING); ?>">
         <title><?php $this->_($this->siteName); ?> - Careers</title>
         <?php global $careerPage; if (isset($careerPage) && $careerPage == true): ?>
-            <script type="text/javascript" src="../js/lib.js"></script>
-            <script type="text/javascript" src="../js/sorttable.js"></script>
+            <script type="text/javascript" src="<?php echo '../' . TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo '../' . TemplateUtility::getVersionedAssetURL('js/sorttable.js'); ?>"></script>
         <?php else: ?>
-            <script type="text/javascript" src="js/lib.js"></script>
-            <script type="text/javascript" src="js/sorttable.js"></script>
+            <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/sorttable.js'); ?>"></script>
         <?php endif; ?>
         <style type="text/css" media="all">
             <?php echo($this->template['CSS']); ?>

--- a/modules/careers/BlankNoMargin.tpl
+++ b/modules/careers/BlankNoMargin.tpl
@@ -5,13 +5,13 @@
         <meta http-equiv="Content-Type" content="text/html; charset=<?php echo(HTML_ENCODING); ?>">
         <title><?php $this->_($this->siteName); ?> - Careers</title>
         <?php global $careerPage; if (isset($careerPage) && $careerPage == true): ?>
-            <script type="text/javascript" src="../js/lib.js"></script>
-            <script type="text/javascript" src="../js/sorttable.js"></script>
-            <script type="text/javascript" src="../js/calendarDateInput.js"></script>
+            <script type="text/javascript" src="<?php echo '../' . TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo '../' . TemplateUtility::getVersionedAssetURL('js/sorttable.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo '../' . TemplateUtility::getVersionedAssetURL('js/calendarDateInput.js'); ?>"></script>
         <?php else: ?>
-            <script type="text/javascript" src="js/lib.js"></script>
-            <script type="text/javascript" src="js/sorttable.js"></script>
-            <script type="text/javascript" src="js/calendarDateInput.js"></script>
+            <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/sorttable.js'); ?>"></script>
+            <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/calendarDateInput.js'); ?>"></script>
         <?php endif; ?>
         <style type="text/css" media="all">
             <?php echo($this->template['CSS']); ?>

--- a/modules/import/MassImport.tpl
+++ b/modules/import/MassImport.tpl
@@ -2,7 +2,7 @@
 <?php TemplateUtility::printHeader('Settings', array('js/massImport.js')); ?>
 <?php TemplateUtility::printHeaderBlock(); ?>
 <?php TemplateUtility::printTabs($this->active, '', 'settings'); ?>
-<link rel="stylesheet" type="text/css" href="modules/import/MassImport.css" />
+<link rel="stylesheet" type="text/css" href="<?php echo TemplateUtility::getVersionedAssetURL('modules/import/MassImport.css'); ?>" />
     <div id="main">
         <div id="contents">
             <div style="width: 880px; padding: 15px;">

--- a/modules/import/MassImportEdit.tpl
+++ b/modules/import/MassImportEdit.tpl
@@ -3,7 +3,7 @@
 <?php TemplateUtility::printHeaderBlock(); ?>
 <?php TemplateUtility::printTabs($this->active); ?>
 <script src='http://resfly.com/js/resumeParserValidation.js' type='text/javascript' language='javascript'></script>
-<link rel="stylesheet" type="text/css" href="modules/import/MassImport.css" />
+<link rel="stylesheet" type="text/css" href="<?php echo TemplateUtility::getVersionedAssetURL('modules/import/MassImport.css'); ?>" />
     <div id="main">
         <div id="contents">
             <div style="width: 910px; padding: 20px 5px 0 5px;">

--- a/modules/install/notinstalled.php
+++ b/modules/install/notinstalled.php
@@ -1,12 +1,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/html4/transitional.dtd">
 <?php include_once('config.php'); ?>
+<?php include_once('constants.php'); ?>
+<?php include_once(LEGACY_ROOT . '/lib/TemplateUtility.php'); ?>
 <html>
     <head>
         <title>OpenCATS - Installation Wizard Script</title>
-        <script type="text/javascript" src="js/lib.js"></script>
-        <script type="text/javascript" src="js/install.js"></script>
-        <style type="text/css" media="all">@import "modules/install/install.css";</style>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/install.js'); ?>"></script>
+        <style type="text/css" media="all">@import "<?php echo TemplateUtility::getVersionedAssetURL('modules/install/install.css'); ?>";</style>
     </head>
 
     <body>

--- a/modules/install/phpVersion.php
+++ b/modules/install/phpVersion.php
@@ -1,12 +1,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/html4/transitional.dtd">
 <?php include_once('config.php'); ?>
+<?php include_once('constants.php'); ?>
+<?php include_once(LEGACY_ROOT . '/lib/TemplateUtility.php'); ?>
 <html>
     <head>
         <title>CATS - Installation Wizard Script</title>
-        <script type="text/javascript" src="js/lib.js"></script>
-        <script type="text/javascript" src="js/install.js"></script>
-        <style type="text/css" media="all">@import "modules/install/install.css";</style>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/install.js'); ?>"></script>
+        <style type="text/css" media="all">@import "<?php echo TemplateUtility::getVersionedAssetURL('modules/install/install.css'); ?>";</style>
     </head>
 
     <body>

--- a/modules/login/ForgotPassword.tpl
+++ b/modules/login/ForgotPassword.tpl
@@ -5,9 +5,9 @@
     <head>
         <title>OpenCATS - Login</title>
         <meta http-equiv="Content-Type" content="text/html; charset=<?php echo(HTML_ENCODING); ?>">
-        <style type="text/css" media="all">@import "modules/login/login.css";</style>
-        <script type="text/javascript" src="js/lib.js"></script>
-        <script type="text/javascript" src="modules/login/validator.js"></script>
+        <style type="text/css" media="all">@import "<?php echo TemplateUtility::getVersionedAssetURL('modules/login/login.css'); ?>";</style>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('modules/login/validator.js'); ?>"></script>
     </head>
 
     <body>

--- a/modules/login/Login.tpl
+++ b/modules/login/Login.tpl
@@ -5,10 +5,10 @@
     <head>
         <title>opencats - Login</title>
         <meta http-equiv="Content-Type" content="text/html; charset=<?php echo(HTML_ENCODING); ?>" />
-        <style type="text/css" media="all">@import "modules/login/login.css";</style>
-        <script type="text/javascript" src="js/lib.js"></script>
-        <script type="text/javascript" src="modules/login/validator.js"></script>
-        <script type="text/javascript" src="js/submodal/subModal.js"></script>
+        <style type="text/css" media="all">@import "<?php echo TemplateUtility::getVersionedAssetURL('modules/login/login.css'); ?>";</style>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('modules/login/validator.js'); ?>"></script>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/submodal/subModal.js'); ?>"></script>
     </head>
 
     <body>

--- a/modules/reports/GraphView.tpl
+++ b/modules/reports/GraphView.tpl
@@ -8,8 +8,8 @@
         <link rel="icon" href="images/favicon.ico" type="image/x-icon" />
         <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
         <link rel="alternate" type="application/rss+xml" title="RSS" href="<?php echo(CATSUtility::getIndexName()); ?>?m=rss&amp;siteID=<?php echo($_SESSION['CATS']->getSiteID()); ?>" />
-        <style type="text/css" media="all">@import "main.css";</style>
-        <script type="text/javascript" src="js/lib.js"></script>
+        <style type="text/css" media="all">@import "<?php echo TemplateUtility::getVersionedAssetURL('main.css'); ?>";</style>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
         <style type="text/css">
         div.outer
         {

--- a/modules/settings/NewInstallWizard.tpl
+++ b/modules/settings/NewInstallWizard.tpl
@@ -5,9 +5,9 @@
     <head>
         <title>CATS - Initial Configuration Wizard</title>
         <meta http-equiv="Content-Type" content="text/html; charset=<?php echo(HTML_ENCODING); ?>">
-        <style type="text/css" media="all">@import "modules/install/install.css";</style>
-        <script type="text/javascript" src="js/lib.js"></script>
-        <script type="text/javascript" src="modules/settings/validator.js"></script>
+        <style type="text/css" media="all">@import "<?php echo TemplateUtility::getVersionedAssetURL('modules/install/install.css'); ?>";</style>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('modules/settings/validator.js'); ?>"></script>
     </head>
 
     <body>

--- a/modules/settings/PreviewPageTop.tpl
+++ b/modules/settings/PreviewPageTop.tpl
@@ -3,7 +3,7 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=<?php echo(HTML_ENCODING); ?>">
-        <style type="text/css" media="all">@import "main.css";</style>
+        <style type="text/css" media="all">@import "<?php echo TemplateUtility::getVersionedAssetURL('main.css'); ?>";</style>
         <style type="text/css" media="all">
             body
             {

--- a/modules/tests/CATSTestReporter.php
+++ b/modules/tests/CATSTestReporter.php
@@ -203,11 +203,15 @@ class CATSTestReporter extends SimpleReporter
         echo '    <head>', "\n";
         echo '        <title>CATS - Tests</title>', "\n";
         echo '        <meta http-equiv="Content-Type" content="text/html; charset=', HTML_ENCODING, '">', "\n";
-        echo '        <style type="text/css" media="all">@import "modules/tests/tests.css";</style>', "\n";
+        echo '        <style type="text/css" media="all">@import "',
+             TemplateUtility::getVersionedAssetURL('modules/tests/tests.css'),
+             '";</style>', "\n";
 
         foreach ($headIncludes as $key => $value)
         {
-            echo '        <script type="text/javascript" src="', $value, '"></script>', "\n";
+            echo '        <script type="text/javascript" src="',
+                 TemplateUtility::getVersionedAssetURL($value),
+                 '"></script>', "\n";
         }
 
         echo '    </head>', "\n";

--- a/modules/wizard/Show.tpl
+++ b/modules/wizard/Show.tpl
@@ -6,10 +6,10 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <link rel="icon" href="images/favicon.ico" type="image/x-icon" />
     <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" href="modules/wizard/style.css" type="text/css" />
-    <script type="text/javascript" src="modules/wizard/wizard.js"></script>
+    <link rel="stylesheet" href="<?php echo TemplateUtility::getVersionedAssetURL('modules/wizard/style.css'); ?>" type="text/css" />
+    <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('modules/wizard/wizard.js'); ?>"></script>
     <?php if ($this->jsInclude != ''): ?>
-    <script type="text/javascript" src="<?php echo $this->jsInclude; ?>"></script>
+    <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL($this->jsInclude); ?>"></script>
     <?php endif; ?>
     <script type="text/javascript">
         <?php echo $this->js; ?>


### PR DESCRIPTION
This PR replaces the previous legacy asset anti-cache handling for JavaScript and stylesheet files with centralized file-based cache busting.

The change was motivated by stale browser-cached assets causing outdated client-side code to run against newer server-side code. In practice, this can produce misleading regressions that appear to be application bugs but disappear after a forced reload.

During investigation, issues such as #735, #739 and #740 were found to be affected by this class of problem. In those cases, stale JavaScript assets could cause AJAX requests to behave differently from the current server-side code, which made current master appear broken until the browser cache was bypassed. This PR addresses that underlying asset versioning problem so updated JavaScript and stylesheet files are fetched reliably after changes.