### PR TITLE
fix: stabilize Docker-based integration test readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
           docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/behat -v -c ./test/behat.yml --suite="security" --format=progress
           # continue-on-error: true
 
+      - name: Docker Diagnostics
+        if: failure()
+        run: |
+          cd docker/
+          docker compose -f docker-compose-test.yml ps
+          docker compose -f docker-compose-test.yml logs --tail=200 opencatsdb integrationtestdb php
+
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,12 @@ jobs:
           docker compose -f docker-compose-test.yml up -d
 
           echo "Waiting for BOTH databases..."
-          timeout 60s bash -c 'until docker compose -f docker-compose-test.yml exec -T opencatsdb mysqladmin ping -h localhost -udev -pdev --silent; do sleep 3; done'
-          timeout 60s bash -c 'until docker compose -f docker-compose-test.yml exec -T integrationtestdb mysqladmin ping -h localhost -udev -pdev --silent; do sleep 3; done'
+          opencatsdb_container="$(docker compose -f docker-compose-test.yml ps -q opencatsdb)"
+          [ -n "$opencatsdb_container" ] || { echo "opencatsdb container ID not found"; exit 1; }
+          timeout 180s bash -c "until [ \"\$(docker inspect --format '{{.State.Health.Status}}' \"${opencatsdb_container}\" 2>/dev/null)\" = \"healthy\" ]; do sleep 3; done"
+          integrationtestdb_container="$(docker compose -f docker-compose-test.yml ps -q integrationtestdb)"
+          [ -n "$integrationtestdb_container" ] || { echo "integrationtestdb container ID not found"; exit 1; }
+          timeout 180s bash -c "until [ \"\$(docker inspect --format '{{.State.Health.Status}}' \"${integrationtestdb_container}\" 2>/dev/null)\" = \"healthy\" ]; do sleep 3; done"
 
           # 2. Pre-clean the integration database
           docker compose -f docker-compose-test.yml exec -T integrationtestdb mysql -udev -pdev -e "DROP DATABASE IF EXISTS cats_integrationtest; CREATE DATABASE cats_integrationtest;"

--- a/docker/docker-compose-test.yml
+++ b/docker/docker-compose-test.yml
@@ -32,6 +32,12 @@ services:
         - MYSQL_USER=dev
         - MYSQL_PASSWORD=dev
         - MYSQL_DATABASE=cats_test
+      healthcheck:
+        test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-udev", "-pdev", "--silent"]
+        interval: 5s
+        timeout: 5s
+        retries: 30
+        start_period: 20s
       volumes:
         - ../test/data/:/test/data/
         - ../test/scripts/:/test/scripts
@@ -48,6 +54,12 @@ services:
         - MYSQL_USER=dev
         - MYSQL_PASSWORD=dev
         - MYSQL_DATABASE=cats_integrationtest
+      healthcheck:
+        test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-udev", "-pdev", "--silent"]
+        interval: 5s
+        timeout: 5s
+        retries: 30
+        start_period: 20s
 
     selenium:
       container_name: selenium_test


### PR DESCRIPTION
This pull request reduces flakiness in the Docker-based integration test workflow by replacing fragile database readiness polling with container health checks and by adding targeted Docker diagnostics for failure cases.

The current workflow could fail intermittently when MariaDB containers were not fully ready before the integration test step continued. In those cases, rerunning CI often succeeded without any code changes. This change makes service readiness explicit and improves visibility when container startup still fails.