### PR TITLE
security: escape activity notes before applying nl2br

### DIFF
--- a/ajax/getPipelineDetails.php
+++ b/ajax/getPipelineDetails.php
@@ -77,7 +77,7 @@ else
              $activity['enteredByLastName'],
              ')</td>';
         echo '<td style="padding-right: 6px; width: 625px;">',
-             nl2br($activity['notes']),
+             nl2br(htmlspecialchars($activity['notes'], ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING)),
              '<br /></td>';
         echo '</tr>';
     }

--- a/modules/activity/Search.tpl
+++ b/modules/activity/Search.tpl
@@ -77,7 +77,7 @@
                             </td>
 
                             <td align="left" valign="top" >
-                                <?php echo(nl2br($activityData['notes'])); ?>
+                                <?php echo(nl2br(htmlspecialchars($activityData['notes'], ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING))); ?>
                             </td>
 
                             <td align="left" valign="top">

--- a/modules/activity/dataGrids.php
+++ b/modules/activity/dataGrids.php
@@ -128,7 +128,7 @@ class ActivityDataGrid extends DataGrid
                                      'alphaNavigation' => true,
                                      'filter'          => 'activity_type.short_description'),  
                                      
-             'Notes' =>      array('pagerRender'    => 'return nl2br($rsData[\'notes\']);', 
+             'Notes' =>      array('pagerRender'    => 'return nl2br(htmlspecialchars($rsData[\'notes\'], ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING));', 
                                      'sortableColumn'  => 'notes',
                                      'pagerWidth'      => 240,
                                      'pagerOptional'   => true,

--- a/modules/candidates/Show.tpl
+++ b/modules/candidates/Show.tpl
@@ -640,7 +640,7 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                         <td align="left" valign="top" id="activityType<?php echo($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo($activityData['activityID']); ?>" data-joborder-id="<?php echo(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
-                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br($activityData['notes'])); ?></td>
+                        <td align="left" valign="top" id="activityNotes<?php echo($activityData['activityID']); ?>"><?php echo(nl2br(htmlspecialchars($activityData['notes'], ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING))); ?></td>
 <?php if (!$this->isPopup): ?>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('candidates.edit') >= ACCESS_LEVEL_EDIT): ?>


### PR DESCRIPTION
This PR addresses @RussH's review feedback on PR #749 regarding inconsistent activity note rendering.

Some activity note outputs already escaped note content before applying `nl2br()`, while several remaining paths still rendered raw note content. This inconsistency left those locations exposed to an XSS risk if notes contained HTML or script content.

The remaining note rendering paths are now aligned with the safer pattern already used elsewhere in the codebase: `nl2br(htmlspecialchars($notes, ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING))`