### PR TITLE
chore: modernize PHPUnit 8 test setup and deprecated APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: mkdir -p reports/behat-default reports/behat-security test/screenshots
 
       - name: Run PHPUnit (Unit Tests)
-        run: ./vendor/bin/phpunit --log-junit reports/unit-report.xml src/OpenCATS/Tests/UnitTests
+        run: ./vendor/bin/phpunit --log-junit reports/unit-report.xml --testsuite UnitTests
 
       - name: Run Integration Tests (Docker)
         run: |
@@ -79,7 +79,7 @@ jobs:
           docker compose -f docker-compose-test.yml exec -T php php -r "echo 'IP for integrationtestdb: ' . gethostbyname('integrationtestdb') . PHP_EOL;"
 
           echo "Running PHPUnit Integration Tests..."
-          docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/phpunit --log-junit /var/www/public/reports/integration-report.xml src/OpenCATS/Tests/IntegrationTests
+          docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/phpunit --log-junit /var/www/public/reports/integration-report.xml --testsuite IntegrationTests
 
           echo "Running Behat Suites..."
           docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/behat -v -c ./test/behat.yml --suite="default" --format=progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: mkdir -p reports/behat-default reports/behat-security test/screenshots
 
       - name: Run PHPUnit (Unit Tests)
-        run: ./vendor/bin/phpunit --log-junit reports/unit-report.xml src/OpenCATS/Tests/UnitTests
+        run: ./vendor/bin/phpunit --log-junit reports/unit-report.xml --testsuite UnitTests
 
       - name: Run Integration Tests (Docker)
         run: |
@@ -78,7 +78,7 @@ jobs:
           docker compose -f docker-compose-test.yml exec -T php php -r "echo 'IP for integrationtestdb: ' . gethostbyname('integrationtestdb') . PHP_EOL;"
 
           echo "Running PHPUnit Integration Tests..."
-          docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/phpunit --log-junit /var/www/public/reports/integration-report.xml src/OpenCATS/Tests/IntegrationTests
+          docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/phpunit --log-junit /var/www/public/reports/integration-report.xml --testsuite IntegrationTests
 
           echo "Running Behat Suites..."
           docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/behat -v -c ./test/behat.yml --suite="default" --format=progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ php:
 script:
 - composer self-update --2
 - composer install
-- "./vendor/bin/phpunit src/OpenCATS/Tests/UnitTests"
+- "./vendor/bin/phpunit --testsuite UnitTests"
 - cd docker/; docker-compose --compatibility -f docker-compose-test.yml up -d
 - docker-compose --compatibility -f docker-compose-test.yml exec php /var/www/public/test/runAllTests.sh
 - cd ..; ./ci/package-code.sh

--- a/README-testing.md
+++ b/README-testing.md
@@ -35,8 +35,8 @@ To mirror the CI environment on your machine:
    ```
 
 4. **Run the suites:**
-   * **PHPUnit Unit Tests:** `docker exec -it opencats_test_php ./vendor/bin/phpunit src/OpenCATS/Tests/UnitTests`
-   * **PHPUnit Integration Tests:** `docker exec -it opencats_test_php ./vendor/bin/phpunit src/OpenCATS/Tests/IntegrationTests`
+   * **PHPUnit Unit Tests:** `docker exec -it opencats_test_php ./vendor/bin/phpunit --testsuite UnitTests`
+   * **PHPUnit Integration Tests:** `docker exec -it opencats_test_php ./vendor/bin/phpunit --testsuite IntegrationTests`
    * **Behat:** `docker exec -it opencats_test_php ./vendor/bin/behat -c ./test/behat.yml`
 
 ---

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php">
+<phpunit bootstrap="src/OpenCATS/Tests/bootstrap.php">
   <testsuites>
     <testsuite name="UnitTests">
       <directory>src/OpenCATS/Tests/UnitTests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit>
+<phpunit bootstrap="vendor/autoload.php">
+  <testsuites>
+    <testsuite name="UnitTests">
+      <directory>src/OpenCATS/Tests/UnitTests</directory>
+    </testsuite>
+    <testsuite name="IntegrationTests">
+      <directory>src/OpenCATS/Tests/IntegrationTests</directory>
+    </testsuite>
+  </testsuites>
   <php>
     <!-- Define HTML_ENCODING for PHPUnit because config.php is not loaded in unit tests. -->
     <const name="HTML_ENCODING" value="UTF-8"/>

--- a/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
+++ b/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
@@ -172,7 +172,7 @@ class DatabaseConnectionTest extends DatabaseTestCase
             false,
             'SELECT query should succeed'
             );
-        $this->assertEquals(
+        $this->assertSame(
             mysqli_num_rows($queryResult),
             1,
             '1 row should be returned'

--- a/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
+++ b/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
@@ -174,9 +174,9 @@ class DatabaseConnectionTest extends DatabaseTestCase
             false,
             'SELECT query should succeed'
             );
-        $this->assertEquals(
-            mysqli_num_rows($queryResult),
+        $this->assertSame(
             1,
+            mysqli_num_rows($queryResult),
             '1 row should be returned'
             );
         $this->assertTrue(

--- a/src/OpenCATS/Tests/IntegrationTests/DatabaseSearchTest.php
+++ b/src/OpenCATS/Tests/IntegrationTests/DatabaseSearchTest.php
@@ -5,11 +5,6 @@ use \OpenCATS\Tests\IntegrationTests\DatabaseTestCase;
 use DatabaseConnection;
 use DatabaseSearch;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/DatabaseSearch.php');
 
 class DatabaseSearchTest extends DatabaseTestCase

--- a/src/OpenCATS/Tests/IntegrationTests/DatabaseTestCase.php
+++ b/src/OpenCATS/Tests/IntegrationTests/DatabaseTestCase.php
@@ -11,12 +11,6 @@ class DatabaseTestCase extends TestCase
     {
         global $mySQLConnection;
         parent::setUp();
-
-        // Ensure roots are defined for legacy includes
-        if (!defined('LEGACY_ROOT')) {
-            define('LEGACY_ROOT', '.');
-        }
-
         include_once('./constants.php');
 
         // We define these for the rest of the app logic,

--- a/src/OpenCATS/Tests/UnitTests/AJAXInterfaceTest.php
+++ b/src/OpenCATS/Tests/UnitTests/AJAXInterfaceTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/AJAXInterface.php');
 
 class AJAXInterfaceTest extends TestCase

--- a/src/OpenCATS/Tests/UnitTests/AddressParserTest.php
+++ b/src/OpenCATS/Tests/UnitTests/AddressParserTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/StringUtility.php');
 include_once(LEGACY_ROOT . '/lib/AddressParser.php'); /* Depends on StringUtility. */
 

--- a/src/OpenCATS/Tests/UnitTests/ArrayUtilityTest.php
+++ b/src/OpenCATS/Tests/UnitTests/ArrayUtilityTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/ArrayUtility.php');
 
 class ArrayUtilityTest extends TestCase

--- a/src/OpenCATS/Tests/UnitTests/BrowserDetectionTest.php
+++ b/src/OpenCATS/Tests/UnitTests/BrowserDetectionTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/BrowserDetection.php');
 
 class BrowserDetectionTest extends TestCase

--- a/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
+++ b/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
@@ -112,7 +112,7 @@ class CompanyRepositoryTests extends TestCase
     private function getDatabaseConnectionMock()
     {
         return $this->getMockBuilder('\DatabaseConnection')
-            ->setMethods(['makeQueryString', 'makeQueryInteger', 'query', 'getLastInsertID'])
+            ->onlyMethods(['makeQueryString', 'makeQueryInteger', 'query', 'getLastInsertID'])
             ->getMock();
     }
     

--- a/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
+++ b/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
@@ -93,9 +93,6 @@ class CompanyRepositoryTests extends TestCase
         $CompanyRepository->persist($this->createCompany(), $historyMock);
     }
     
-    /**
-     * @expectedException OpenCATS\Entity\CompanyRepositoryException
-     */
     function test_persist_FailToCreateNewCompany_ThrowsException()
     {
         $databaseConnectionMock = $this->getDatabaseConnectionMock();
@@ -103,6 +100,7 @@ class CompanyRepositoryTests extends TestCase
             ->willReturn(false);
         $historyMock = $this->getHistoryMock();
         $CompanyRepository = new CompanyRepository($databaseConnectionMock);
+        $this->expectException(\OpenCATS\Entity\CompanyRepositoryException::class);
         $CompanyRepository->persist($this->createCompany(), $historyMock);
     }
     

--- a/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
+++ b/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
@@ -34,28 +34,38 @@ class CompanyRepositoryTests extends TestCase
     function test_persist_CreatesNewCompany_InputValuesAreEscaped()
     {
         $databaseConnectionMock = $this->getDatabaseConnectionMock();
+        $expectedStringValues = [
+            self::COMPANY_NAME,
+            self::ADDRESS,
+            self::ADDRESS2,
+            self::CITY,
+            self::STATE,
+            self::ZIP_CODE,
+            self::PHONE_NUMBER_ONE,
+            self::PHONE_NUMBER_TWO,
+            self::FAX_NUMBER,
+            self::URL,
+            self::KEY_TECHNOLOGIES,
+            self::NOTES
+        ];
+        $stringCallIndex = 0;
         $databaseConnectionMock->expects($this->exactly(12))
             ->method('makeQueryString')
-            ->withConsecutive(
-                [$this->equalTo(self::COMPANY_NAME)],
-                [$this->equalTo(self::ADDRESS)],
-                [$this->equalTo(self::ADDRESS2)],
-                [$this->equalTo(self::CITY)],
-                [$this->equalTo(self::STATE)],
-                [$this->equalTo(self::ZIP_CODE)],
-                [$this->equalTo(self::PHONE_NUMBER_ONE)],
-                [$this->equalTo(self::PHONE_NUMBER_TWO)],
-                [$this->equalTo(self::FAX_NUMBER)],
-                [$this->equalTo(self::URL)],
-                [$this->equalTo(self::KEY_TECHNOLOGIES)],
-                [$this->equalTo(self::NOTES)]
-            );
+            ->willReturnCallback(function($value) use ($expectedStringValues, &$stringCallIndex) {
+                $this->assertSame($expectedStringValues[$stringCallIndex], $value);
+                $stringCallIndex++;
+            });
+        $expectedIntegerValues = [
+            self::ENTERED_BY,
+            self::OWNER
+        ];
+        $integerCallIndex = 0;
         $databaseConnectionMock->expects($this->exactly(2))
             ->method('makeQueryInteger')
-            ->withConsecutive(
-                [$this->equalTo(self::ENTERED_BY)],
-                [$this->equalTo(self::OWNER)]
-            );
+            ->willReturnCallback(function($value) use ($expectedIntegerValues, &$integerCallIndex) {
+                $this->assertSame($expectedIntegerValues[$integerCallIndex], $value);
+                $integerCallIndex++;
+            });
         $databaseConnectionMock->method('query')
             ->willReturn(true);
         $databaseConnectionMock->method('getLastInsertID')
@@ -86,8 +96,9 @@ class CompanyRepositoryTests extends TestCase
         $historyMock = $this->getHistoryMock();
         $historyMock->expects($this->exactly(1))
             ->method('storeHistoryNew')
-            ->withConsecutive(
-                [DATA_ITEM_COMPANY, self::COMPANY_ID]
+            ->with(
+                $this->equalTo(DATA_ITEM_COMPANY),
+                $this->equalTo(self::COMPANY_ID)
             );
         $CompanyRepository = new CompanyRepository($databaseConnectionMock);
         $CompanyRepository->persist($this->createCompany(), $historyMock);

--- a/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
+++ b/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
@@ -4,12 +4,8 @@ use PHPUnit\Framework\TestCase;
 use OpenCATS\Entity\CompanyRepository;
 use OpenCATS\Entity\Company;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/History.php');
+include_once(LEGACY_ROOT . '/lib/DatabaseConnection.php');
 
 class CompanyRepositoryTests extends TestCase
 {
@@ -123,6 +119,7 @@ class CompanyRepositoryTests extends TestCase
     private function getDatabaseConnectionMock()
     {
         return $this->getMockBuilder('\DatabaseConnection')
+            ->disableOriginalConstructor()
             ->onlyMethods(['makeQueryString', 'makeQueryInteger', 'query', 'getLastInsertID'])
             ->getMock();
     }

--- a/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
+++ b/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
@@ -4,12 +4,8 @@ use PHPUnit\Framework\TestCase;
 use OpenCATS\Entity\CompanyRepository;
 use OpenCATS\Entity\Company;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/History.php');
+include_once(LEGACY_ROOT . '/lib/DatabaseConnection.php');
 
 class CompanyRepositoryTests extends TestCase
 {
@@ -125,6 +121,7 @@ class CompanyRepositoryTests extends TestCase
     private function getDatabaseConnectionMock()
     {
         return $this->getMockBuilder('\DatabaseConnection')
+            ->disableOriginalConstructor()
             ->onlyMethods(['makeQueryString', 'makeQueryInteger', 'query', 'getLastInsertID'])
             ->getMock();
     }

--- a/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
+++ b/src/OpenCATS/Tests/UnitTests/CompanyRepositoryTest.php
@@ -34,28 +34,40 @@ class CompanyRepositoryTests extends TestCase
     function test_persist_CreatesNewCompany_InputValuesAreEscaped()
     {
         $databaseConnectionMock = $this->getDatabaseConnectionMock();
+        $expectedStringValues = [
+            self::COMPANY_NAME,
+            self::ADDRESS,
+            self::ADDRESS2,
+            self::CITY,
+            self::STATE,
+            self::ZIP_CODE,
+            self::PHONE_NUMBER_ONE,
+            self::PHONE_NUMBER_TWO,
+            self::FAX_NUMBER,
+            self::URL,
+            self::KEY_TECHNOLOGIES,
+            self::NOTES
+        ];
+        $stringCallIndex = 0;
         $databaseConnectionMock->expects($this->exactly(12))
             ->method('makeQueryString')
-            ->withConsecutive(
-                [$this->equalTo(self::COMPANY_NAME)],
-                [$this->equalTo(self::ADDRESS)],
-                [$this->equalTo(self::ADDRESS2)],
-                [$this->equalTo(self::CITY)],
-                [$this->equalTo(self::STATE)],
-                [$this->equalTo(self::ZIP_CODE)],
-                [$this->equalTo(self::PHONE_NUMBER_ONE)],
-                [$this->equalTo(self::PHONE_NUMBER_TWO)],
-                [$this->equalTo(self::FAX_NUMBER)],
-                [$this->equalTo(self::URL)],
-                [$this->equalTo(self::KEY_TECHNOLOGIES)],
-                [$this->equalTo(self::NOTES)]
-            );
+            ->willReturnCallback(function($value) use ($expectedStringValues, &$stringCallIndex) {
+                $this->assertSame($expectedStringValues[$stringCallIndex], $value);
+                $stringCallIndex++;
+                return "'" . $value . "'";
+            });
+        $expectedIntegerValues = [
+            self::ENTERED_BY,
+            self::OWNER
+        ];
+        $integerCallIndex = 0;
         $databaseConnectionMock->expects($this->exactly(2))
             ->method('makeQueryInteger')
-            ->withConsecutive(
-                [$this->equalTo(self::ENTERED_BY)],
-                [$this->equalTo(self::OWNER)]
-            );
+            ->willReturnCallback(function($value) use ($expectedIntegerValues, &$integerCallIndex) {
+                $this->assertSame($expectedIntegerValues[$integerCallIndex], $value);
+                $integerCallIndex++;
+                return (string) $value;
+            });
         $databaseConnectionMock->method('query')
             ->willReturn(true);
         $databaseConnectionMock->method('getLastInsertID')
@@ -86,8 +98,9 @@ class CompanyRepositoryTests extends TestCase
         $historyMock = $this->getHistoryMock();
         $historyMock->expects($this->exactly(1))
             ->method('storeHistoryNew')
-            ->withConsecutive(
-                [DATA_ITEM_COMPANY, self::COMPANY_ID]
+            ->with(
+                $this->equalTo(DATA_ITEM_COMPANY),
+                $this->equalTo(self::COMPANY_ID)
             );
         $CompanyRepository = new CompanyRepository($databaseConnectionMock);
         $CompanyRepository->persist($this->createCompany(), $historyMock);

--- a/src/OpenCATS/Tests/UnitTests/DateUtilityTest.php
+++ b/src/OpenCATS/Tests/UnitTests/DateUtilityTest.php
@@ -38,11 +38,6 @@
 
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/constants.php');
 include_once(LEGACY_ROOT . '/lib/StringUtility.php');
 include_once(LEGACY_ROOT . '/lib/DateUtility.php');   /* Depends on StringUtility. */

--- a/src/OpenCATS/Tests/UnitTests/FileUtilityTest.php
+++ b/src/OpenCATS/Tests/UnitTests/FileUtilityTest.php
@@ -52,22 +52,22 @@ class FileUtilityTest extends TestCase
         $directoryD = FileUtility::getUniqueDirectory('attachments');
 
         /* Make sure all directory names look like md5 strings. */
-        $this->assertEquals(
+        $this->assertSame(
             strlen($directoryA),
             32,
             sprintf("'%s' should be 32 characters long", $directoryA)
             );
-        $this->assertEquals(
+        $this->assertSame(
             strlen($directoryB),
             32,
             sprintf("'%s' should be 32 characters long", $directoryB)
             );
-        $this->assertEquals(
+        $this->assertSame(
             strlen($directoryC),
             32,
             sprintf("'%s' should be 32 characters long", $directoryB)
             );
-        $this->assertEquals(
+        $this->assertSame(
             strlen($directoryD),
             32,
             sprintf("'%s' should be 32 characters long", $directoryB)
@@ -76,32 +76,32 @@ class FileUtilityTest extends TestCase
         /* Make sure extra data is actually being added (directory names
          * should not be identical).
          */
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryA,
             $directoryB,
             sprintf("'%s' should not equal '%s'", $directoryA, $directoryB)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryA,
             $directoryC,
             sprintf("'%s' should not equal '%s'", $directoryA, $directoryC)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryA,
             $directoryD,
             sprintf("'%s' should not equal '%s'", $directoryA, $directoryD)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryB,
             $directoryC,
             sprintf("'%s' should not equal '%s'", $directoryB, $directoryC)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryB,
             $directoryD,
             sprintf("'%s' should not equal '%s'", $directoryB, $directoryD)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryC,
             $directoryD,
             sprintf("'%s' should not equal '%s'", $directoryC, $directoryD)

--- a/src/OpenCATS/Tests/UnitTests/FileUtilityTest.php
+++ b/src/OpenCATS/Tests/UnitTests/FileUtilityTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/FileUtility.php');
 
 class FileUtilityTest extends TestCase

--- a/src/OpenCATS/Tests/UnitTests/FileUtilityTest.php
+++ b/src/OpenCATS/Tests/UnitTests/FileUtilityTest.php
@@ -52,56 +52,56 @@ class FileUtilityTest extends TestCase
         $directoryD = FileUtility::getUniqueDirectory('attachments');
 
         /* Make sure all directory names look like md5 strings. */
-        $this->assertEquals(
-            strlen($directoryA),
+        $this->assertSame(
             32,
+            strlen($directoryA),
             sprintf("'%s' should be 32 characters long", $directoryA)
             );
-        $this->assertEquals(
+        $this->assertSame(
+            32,
             strlen($directoryB),
-            32,
             sprintf("'%s' should be 32 characters long", $directoryB)
             );
-        $this->assertEquals(
+        $this->assertSame(
+            32,
             strlen($directoryC),
-            32,
             sprintf("'%s' should be 32 characters long", $directoryB)
             );
-        $this->assertEquals(
-            strlen($directoryD),
+        $this->assertSame(
             32,
+            strlen($directoryD),
             sprintf("'%s' should be 32 characters long", $directoryB)
             );
 
         /* Make sure extra data is actually being added (directory names
          * should not be identical).
          */
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryA,
             $directoryB,
             sprintf("'%s' should not equal '%s'", $directoryA, $directoryB)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryA,
             $directoryC,
             sprintf("'%s' should not equal '%s'", $directoryA, $directoryC)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryA,
             $directoryD,
             sprintf("'%s' should not equal '%s'", $directoryA, $directoryD)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryB,
             $directoryC,
             sprintf("'%s' should not equal '%s'", $directoryB, $directoryC)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryB,
             $directoryD,
             sprintf("'%s' should not equal '%s'", $directoryB, $directoryD)
             );
-        $this->assertNotEquals(
+        $this->assertNotSame(
             $directoryC,
             $directoryD,
             sprintf("'%s' should not equal '%s'", $directoryC, $directoryD)

--- a/src/OpenCATS/Tests/UnitTests/ResultSetUtilityTest.php
+++ b/src/OpenCATS/Tests/UnitTests/ResultSetUtilityTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/ResultSetUtility.php');
 
 class ResultSetUtilityTest extends TestCase

--- a/src/OpenCATS/Tests/UnitTests/SessionCSRFTest.php
+++ b/src/OpenCATS/Tests/UnitTests/SessionCSRFTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/Session.php');
 
 class SessionCSRFTest extends TestCase

--- a/src/OpenCATS/Tests/UnitTests/SessionCSRFTest.php
+++ b/src/OpenCATS/Tests/UnitTests/SessionCSRFTest.php
@@ -26,7 +26,7 @@ class SessionCSRFTest extends TestCase
         $t1 = $this->_session->getCSRFToken();
         $t2 = $this->_session->getCSRFToken();
 
-        $this->assertEquals($t1, $t2);
+        $this->assertSame($t1, $t2);
     }
 
     function testRotateCSRFTokenChangesToken()
@@ -34,8 +34,8 @@ class SessionCSRFTest extends TestCase
         $old = $this->_session->getCSRFToken();
         $new = $this->_session->rotateCSRFToken();
 
-        $this->assertNotEquals($old, $new);
-        $this->assertEquals($new, $this->_session->getCSRFToken());
+        $this->assertNotSame($old, $new);
+        $this->assertSame($new, $this->_session->getCSRFToken());
         $this->assertSame(64, strlen($new));
         $this->assertTrue(ctype_xdigit($new));
     }

--- a/src/OpenCATS/Tests/UnitTests/StringUtilityTest.php
+++ b/src/OpenCATS/Tests/UnitTests/StringUtilityTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/StringUtility.php');
 
 class StringUtilityTest extends TestCase

--- a/src/OpenCATS/Tests/UnitTests/TemplateEscapeTest.php
+++ b/src/OpenCATS/Tests/UnitTests/TemplateEscapeTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/Template.php');
 
 class TemplateEscapeStringableFixture

--- a/src/OpenCATS/Tests/UnitTests/TemplateEscapeTest.php
+++ b/src/OpenCATS/Tests/UnitTests/TemplateEscapeTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/Template.php');
 
 class TemplateEscapeTest extends TestCase

--- a/src/OpenCATS/Tests/UnitTests/VCardTest.php
+++ b/src/OpenCATS/Tests/UnitTests/VCardTest.php
@@ -1,11 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if( !defined('LEGACY_ROOT') )
-{
-    define('LEGACY_ROOT', '.');
-}
-
 include_once(LEGACY_ROOT . '/lib/VCard.php');
 
 class VCardTest extends TestCase

--- a/src/OpenCATS/Tests/UnitTests/VCardTest.php
+++ b/src/OpenCATS/Tests/UnitTests/VCardTest.php
@@ -10,6 +10,18 @@ include_once(LEGACY_ROOT . '/lib/VCard.php');
 
 class VCardTest extends TestCase
 {
+    private function assertRegexCompat($pattern, $value)
+    {
+        if( method_exists($this, 'assertMatchesRegularExpression') )
+        {
+            $this->assertMatchesRegularExpression($pattern, $value);
+        }
+        else
+        {
+            $this->assertSame(1, preg_match($pattern, $value));
+        }
+    }
+
     function testVersion()
     {
         $this->assertSame(VCard::VCARD_VERSION, '2.1');
@@ -31,10 +43,7 @@ class VCardTest extends TestCase
         $this->assertSame($outputLines[3], 'FN:John Smith');
 
         /* Test revision timestamp. */
-        $this->assertRegExp(
-            '/^REV:\d{8}T\d{6}$/',
-            $outputLines[4]
-            );
+        $this->assertRegexCompat('/^REV:\d{8}T\d{6}$/', $outputLines[4]);
         $currentREVNumeric = date('YmdHis');
 
         $vCardREVNumeric = preg_replace('/REV:|T/', '', $outputLines[4]);
@@ -91,10 +100,7 @@ class VCardTest extends TestCase
         $this->assertSame($outputLines[10], 'URL:http://www.slashdot.org');
 
         /* Test revision timestamp. */
-        $this->assertRegExp(
-            '/^REV:\d{8}T\d{6}$/',
-            $outputLines[11]
-            );
+        $this->assertRegexCompat('/^REV:\d{8}T\d{6}$/', $outputLines[11]);
         $currentREVNumeric = date('YmdHis');
 
         $vCardREVNumeric = preg_replace('/REV:|T/', '', $outputLines[11]);

--- a/src/OpenCATS/Tests/bootstrap.php
+++ b/src/OpenCATS/Tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+if (!defined('LEGACY_ROOT')) {
+    define('LEGACY_ROOT', '.');
+}

--- a/test/runAllTests.sh
+++ b/test/runAllTests.sh
@@ -3,6 +3,6 @@ cd /var/www/public/
 dockerize -wait tcp://opencats_test_mariadb:3306 -wait http://opencats_test_web:80 -timeout 30s
 php test/scripts/waitForDb.php
 cat config.php
-./vendor/bin/phpunit src/OpenCATS/Tests/IntegrationTests
+./vendor/bin/phpunit --testsuite IntegrationTests
 ./vendor/bin/behat -v -c ./test/behat.yml --suite="default"
 ./vendor/bin/behat -v -c ./test/behat.yml --suite="security"

--- a/test/runAllTests.sh
+++ b/test/runAllTests.sh
@@ -3,6 +3,6 @@ cd /var/www/public/
 dockerize -wait tcp://opencats_test_mariadb:3306 -wait http://opencats_test_web:80 -timeout 30s
 php modules/tests/waitForDb.php
 cat config.php
-./vendor/bin/phpunit src/OpenCATS/Tests/IntegrationTests
+./vendor/bin/phpunit --testsuite IntegrationTests
 ./vendor/bin/behat -v -c ./test/behat.yml --suite="default"
 ./vendor/bin/behat -v -c ./test/behat.yml --suite="security"


### PR DESCRIPTION
This updates the PHPUnit 8 test setup to reduce deprecated API usage and make the test suite easier to maintain on PHP 7.2.

It centralizes the test bootstrap, expands the PHPUnit configuration with dedicated test suites and updates CI and test documentation to use the shared configuration.

It also replaces deprecated or outdated PHPUnit patterns in the existing tests, including regex assertions, exception expectations and mock builder usage, while keeping the changes minimal and close to the current test structure.