### PR TITLE
fix: normalize candidate activity note escaping

### DIFF
--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -3529,17 +3529,7 @@ class CandidatesUI extends UserInterface
             {
                 /* Log status changes as activities in the dedicated status flow. */
                 $activityEntries = new ActivityEntries($this->_siteID);
-                $activityNote = htmlspecialchars(
-                    sprintf('Status change: %s', $newStatusDescription)
-                );
-                foreach ($statusRS as $statusData)
-                {
-                    $activityNote = StringUtility::replaceOnce(
-                        $statusData['status'],
-                        '<span style="color: #ff6c00;">' . $statusData['status'] . '</span>',
-                        $activityNote
-                    );
-                }
+                $activityNote = sprintf('Status change: %s', $newStatusDescription);
                 $activityEntries->add(
                     $candidateID,
                     DATA_ITEM_CANDIDATE,

--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -3150,7 +3150,6 @@ class CandidatesUI extends UserInterface
             }
 
             $activityNote = $this->getTrimmedInput('activityNote', $_POST);
-            $activityNote = htmlspecialchars($activityNote);
 
             /* Add the activity entry. */
             $activityEntries->add(
@@ -3356,7 +3355,7 @@ class CandidatesUI extends UserInterface
         $this->_template->assign('candidateID', $candidateID);
         $this->_template->assign('regardingID', $regardingID);
         $this->_template->assign('activityAdded', $activityAdded);
-        $this->_template->assign('activityDescription', $activityNote);
+        $this->_template->assign('activityDescription', htmlspecialchars($activityNote, ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING));
         $this->_template->assign('activityType', $activityTypeDescription);
         $this->_template->assign('eventScheduled', $eventScheduled);
         $this->_template->assign('eventHTML', $eventHTML);


### PR DESCRIPTION
This PR follows up on #702.

It removes pre-storage HTML encoding for manually entered candidate activity notes and stops persisting legacy inline HTML in candidate status change activity notes. As a result, candidate activity notes are stored as plain text and remain aligned with the current output escaping direction.