### PR TITLE
feat: allow manually setting activity date and time

### DIFF
--- a/lib/ActivityEntries.php
+++ b/lib/ActivityEntries.php
@@ -82,14 +82,25 @@ class ActivityEntries
      * @param string Activity notes.
      * @param integer Entered-by user ID.
      * @param integer Job Order ID; -1 for general (stored as NULL).
+     * @param string Date created timestamp (YYYY-MM-DD HH:MM:SS); false for NOW().
      * @return integer New Activity ID; -1 on failure.
      */
     public function add($dataItemID, $dataItemType, $activityType,
-        $activityNotes, $enteredBy, $jobOrderID = -1)
+        $activityNotes, $enteredBy, $jobOrderID = -1, $dateCreated = false)
     {
         if (!ctype_digit((string) $jobOrderID) || (int) $jobOrderID <= 0)
         {
             $jobOrderID = -1;
+        }
+
+        if (is_string($dateCreated) &&
+            preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $dateCreated))
+        {
+            $dateCreatedSQL = $this->_db->makeQueryString($dateCreated);
+        }
+        else
+        {
+            $dateCreatedSQL = 'NOW()';
         }
 
         $sql = sprintf(
@@ -112,8 +123,8 @@ class ActivityEntries
                 %s,
                 %s,
                 %s,
-                NOW(),
-                NOW()
+                %s,
+                %s
             )",
             $this->_db->makeQueryInteger($dataItemID),
             $this->_db->makeQueryInteger($dataItemType),
@@ -121,7 +132,9 @@ class ActivityEntries
             $this->_db->makeQueryInteger($enteredBy),
             $this->_db->makeQueryInteger($activityType),
             $this->_db->makeQueryString($activityNotes),
-            $this->_siteID
+            $this->_siteID,
+            $dateCreatedSQL,
+            $dateCreatedSQL
         );
 
         $queryResult = $this->_db->query($sql);

--- a/lib/ActivityEntries.php
+++ b/lib/ActivityEntries.php
@@ -82,14 +82,25 @@ class ActivityEntries
      * @param string Activity notes.
      * @param integer Entered-by user ID.
      * @param integer Job Order ID; -1 for general (stored as NULL).
+     * @param string Date created timestamp (YYYY-MM-DD HH:MM:SS); false for NOW().
      * @return integer New Activity ID; -1 on failure.
      */
     public function add($dataItemID, $dataItemType, $activityType,
-        $activityNotes, $enteredBy, $jobOrderID = -1)
+        $activityNotes, $enteredBy, $jobOrderID = -1, $dateCreated = false)
     {
         if (!ctype_digit((string) $jobOrderID) || (int) $jobOrderID <= 0)
         {
             $jobOrderID = -1;
+        }
+
+        if (is_string($dateCreated) &&
+            preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $dateCreated))
+        {
+            $dateCreatedSQL = $this->_db->makeQueryString($dateCreated);
+        }
+        else
+        {
+            $dateCreatedSQL = 'NOW()';
         }
 
         $sql = sprintf(
@@ -112,7 +123,7 @@ class ActivityEntries
                 %s,
                 %s,
                 %s,
-                NOW(),
+                %s,
                 NOW()
             )",
             $this->_db->makeQueryInteger($dataItemID),
@@ -121,7 +132,8 @@ class ActivityEntries
             $this->_db->makeQueryInteger($enteredBy),
             $this->_db->makeQueryInteger($activityType),
             $this->_db->makeQueryString($activityNotes),
-            $this->_siteID
+            $this->_siteID,
+            $dateCreatedSQL
         );
 
         $queryResult = $this->_db->query($sql);

--- a/modules/candidates/AddActivityScheduleEventModal.tpl
+++ b/modules/candidates/AddActivityScheduleEventModal.tpl
@@ -23,6 +23,41 @@
 <?php endif; ?>
 
         <table class="editTable" width="560">
+<?php if (!$this->onlyScheduleEvent): ?>
+            <tr id="activityDateTR">
+                <td class="tdVertical">
+                    <label id="activityDateLabel" for="activityDate_Month_ID">Date:</label>
+                </td>
+                <td class="tdData">
+                    <script type="text/javascript">DateInput('activityDate', true, (typeof window.CATSUserDateFormat !== 'undefined' ? window.CATSUserDateFormat : 'MM-DD-YY'), '', -1);</script>
+                </td>
+            </tr>
+
+            <tr id="activityTimeTR">
+                <td class="tdVertical">
+                    <label id="activityTimeLabel" for="activityHour">Time:</label>
+                </td>
+                <td class="tdData">
+                    <select id="activityHour" name="activityHour" class="inputbox" style="width: 40px;">
+                        <?php for ($i = 1; $i <= 12; ++$i): ?>
+                            <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                        <?php endfor; ?>
+                    </select>&nbsp;
+                    <select id="activityMinute" name="activityMinute" class="inputbox" style="width: 40px;">
+                        <?php for ($i = 0; $i <= 59; ++$i): ?>
+                            <option value="<?php echo(sprintf('%02d', $i)); ?>">
+                                <?php echo(sprintf('%02d', $i)); ?>
+                            </option>
+                        <?php endfor; ?>
+                    </select>&nbsp;
+                    <select id="activityMeridiem" name="activityMeridiem" class="inputbox" style="width: 45px;">
+                        <option value="AM">AM</option>
+                        <option value="PM">PM</option>
+                    </select>
+                </td>
+            </tr>
+<?php endif; ?>
+
             <tr id="visibleTR" <?php if ($this->onlyScheduleEvent): ?>style="display:none;"<?php endif; ?>>
                 <td class="tdVertical">
                     <label id="regardingIDLabel" for="regardingID">Regarding:</label>
@@ -187,6 +222,15 @@
     <script type="text/javascript">
         if (!<?php echo($this->onlyScheduleEvent ? 'true' : 'false'); ?>)
         {
+            var now = new Date();
+            var currentHour = now.getHours() % 12;
+            if (currentHour == 0)
+            {
+                currentHour = 12;
+            }
+            document.getElementById('activityHour').value = currentHour.toString();
+            document.getElementById('activityMinute').value = (now.getMinutes() < 10 ? '0' : '') + now.getMinutes();
+            document.getElementById('activityMeridiem').value = (now.getHours() >= 12 ? 'PM' : 'AM');
             document.logActivityForm.activityNote.focus();
         }
     </script>

--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -3152,6 +3152,45 @@ class CandidatesUI extends UserInterface
             $activityNote = $this->getTrimmedInput('activityNote', $_POST);
             $activityNote = htmlspecialchars($activityNote);
 
+            $activityDateCreated = false;
+            $dateFormatFlag = $_SESSION['CATS']->isDateDMY()
+                ? DATE_FORMAT_DDMMYY
+                : DATE_FORMAT_MMDDYY;
+            $activityDate = $this->getTrimmedInput('activityDate', $_POST);
+            if (!empty($activityDate) &&
+                DateUtility::validate('-', $activityDate, $dateFormatFlag) &&
+                isset($_POST['activityHour']) && isset($_POST['activityMinute']) &&
+                isset($_POST['activityMeridiem']) &&
+                ctype_digit((string) $_POST['activityHour']) &&
+                ctype_digit((string) $_POST['activityMinute']) &&
+                ($_POST['activityMeridiem'] == 'AM' || $_POST['activityMeridiem'] == 'PM'))
+            {
+                $activityHour = (int) $_POST['activityHour'];
+                $activityMinute = (int) $_POST['activityMinute'];
+
+                if ($activityHour >= 1 && $activityHour <= 12 &&
+                    $activityMinute >= 0 && $activityMinute <= 59)
+                {
+                    $activityHour = $activityHour % 12;
+                    if ($_POST['activityMeridiem'] == 'PM')
+                    {
+                        $activityHour += 12;
+                    }
+
+                    $activityDateCreated = sprintf(
+                        '%s %02d:%02d:00',
+                        DateUtility::convert(
+                            '-',
+                            $activityDate,
+                            $dateFormatFlag,
+                            DATE_FORMAT_YYYYMMDD
+                        ),
+                        $activityHour,
+                        $activityMinute
+                    );
+                }
+            }
+
             /* Add the activity entry. */
             $activityEntries->add(
                 $candidateID,
@@ -3159,7 +3198,8 @@ class CandidatesUI extends UserInterface
                 $activityTypeID,
                 $activityNote,
                 $this->_userID,
-                $regardingID
+                $regardingID,
+                $activityDateCreated
             );
             $activityTypeDescription = ResultSetUtility::getColumnValueByIDValue(
                 $activityTypes, 'typeID', $activityTypeID, 'type'

--- a/modules/contacts/AddActivityScheduleEventModal.tpl
+++ b/modules/contacts/AddActivityScheduleEventModal.tpl
@@ -17,6 +17,41 @@
         <input type="hidden" id="contactID" name="contactID" value="<?php echo($this->contactID); ?>" />
 
         <table class="editTable" width="560">
+            <?php if(!$this->onlyScheduleEvent): ?>
+            <tr id="activityDateTR">
+                <td class="tdVertical">
+                    <label id="activityDateLabel" for="activityDate_Month_ID">Date:</label>
+                </td>
+                <td class="tdData">
+                    <script type="text/javascript">DateInput('activityDate', true, (typeof window.CATSUserDateFormat !== 'undefined' ? window.CATSUserDateFormat : 'MM-DD-YY'), '', -1);</script>
+                </td>
+            </tr>
+
+            <tr id="activityTimeTR">
+                <td class="tdVertical">
+                    <label id="activityTimeLabel" for="activityHour">Time:</label>
+                </td>
+                <td class="tdData">
+                    <select id="activityHour" name="activityHour" class="inputbox" style="width: 40px;">
+                        <?php for ($i = 1; $i <= 12; ++$i): ?>
+                            <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                        <?php endfor; ?>
+                    </select>&nbsp;
+                    <select id="activityMinute" name="activityMinute" class="inputbox" style="width: 40px;">
+                        <?php for ($i = 0; $i <= 59; ++$i): ?>
+                            <option value="<?php echo(sprintf('%02d', $i)); ?>">
+                                <?php echo(sprintf('%02d', $i)); ?>
+                            </option>
+                        <?php endfor; ?>
+                    </select>&nbsp;
+                    <select id="activityMeridiem" name="activityMeridiem" class="inputbox" style="width: 45px;">
+                        <option value="AM">AM</option>
+                        <option value="PM">PM</option>
+                    </select>
+                </td>
+            </tr>
+            <?php endif; ?>
+
             <tr id="visibleTR" <?php if($this->onlyScheduleEvent): ?>style="display:none;"<?php endif; ?>>
                 <td class="tdVertical">
                     <label id="regardingIDLabel" for="regardingID">Regarding:</label>
@@ -151,7 +186,23 @@
     </form>
 
     <script type="text/javascript">
-        document.changePipelineStatusForm.activityNote.focus();
+        if (!<?php echo($this->onlyScheduleEvent ? 'true' : 'false'); ?>)
+        {
+            var now = new Date();
+            var currentHour = now.getHours() % 12;
+            if (currentHour == 0)
+            {
+                currentHour = 12;
+            }
+            document.getElementById('activityHour').value = currentHour.toString();
+            document.getElementById('activityMinute').value = (now.getMinutes() < 10 ? '0' : '') + now.getMinutes();
+            document.getElementById('activityMeridiem').value = (now.getHours() >= 12 ? 'PM' : 'AM');
+            document.logActivityForm.activityNote.focus();
+        }
+        else
+        {
+            document.getElementById('title').focus();
+        }
     </script>
 
 <?php else: ?>

--- a/modules/contacts/ContactsUI.php
+++ b/modules/contacts/ContactsUI.php
@@ -1363,6 +1363,45 @@ class ContactsUI extends UserInterface
 
             $activityNote = $this->getTrimmedInput('activityNote', $_POST);
 
+            $activityDateCreated = false;
+            $dateFormatFlag = $_SESSION['CATS']->isDateDMY()
+                ? DATE_FORMAT_DDMMYY
+                : DATE_FORMAT_MMDDYY;
+            $activityDate = $this->getTrimmedInput('activityDate', $_POST);
+            if (!empty($activityDate) &&
+                DateUtility::validate('-', $activityDate, $dateFormatFlag) &&
+                isset($_POST['activityHour']) && isset($_POST['activityMinute']) &&
+                isset($_POST['activityMeridiem']) &&
+                ctype_digit((string) $_POST['activityHour']) &&
+                ctype_digit((string) $_POST['activityMinute']) &&
+                ($_POST['activityMeridiem'] == 'AM' || $_POST['activityMeridiem'] == 'PM'))
+            {
+                $activityHour = (int) $_POST['activityHour'];
+                $activityMinute = (int) $_POST['activityMinute'];
+
+                if ($activityHour >= 1 && $activityHour <= 12 &&
+                    $activityMinute >= 0 && $activityMinute <= 59)
+                {
+                    $activityHour = $activityHour % 12;
+                    if ($_POST['activityMeridiem'] == 'PM')
+                    {
+                        $activityHour += 12;
+                    }
+
+                    $activityDateCreated = sprintf(
+                        '%s %02d:%02d:00',
+                        DateUtility::convert(
+                            '-',
+                            $activityDate,
+                            $dateFormatFlag,
+                            DATE_FORMAT_YYYYMMDD
+                        ),
+                        $activityHour,
+                        $activityMinute
+                    );
+                }
+            }
+
             /* Add the activity entry. */
             $activityID = $activityEntries->add(
                 $contactID,
@@ -1370,7 +1409,8 @@ class ContactsUI extends UserInterface
                 $activityTypeID,
                 $activityNote,
                 $this->_userID,
-                $regardingID
+                $regardingID,
+                $activityDateCreated
             );
             $activityTypeDescription = ResultSetUtility::getColumnValueByIDValue(
                 $activityTypes, 'typeID', $activityTypeID, 'type'

--- a/test/features/activities.feature
+++ b/test/features/activities.feature
@@ -24,3 +24,26 @@ Feature: Activities
     And I should see "Yesterday"
     And I should see "Today"
     And I should see "Last week"
+
+  @javascript
+  Scenario: Log activity with manual date and time
+    Given I am authenticated as "Administrator"
+    And There is a person called "Samwise Gamgee" with "keySkills=gardening"
+    And I am on "/index.php?m=candidates"
+    And I follow "Samwise"
+    And I follow "Log an Activity"
+    And I wait for the activity note box to appear
+    And I switch to the iframe "popupInner"
+    And I select "Not reached" from "activityTypeID"
+    And fill in "activityNote" with "Manual timestamp note"
+    And I set hidden field "activityDate" to "07-07-26"
+    And I select "4" from "activityHour"
+    And I select "37" from "activityMinute"
+    And I select "PM" from "activityMeridiem"
+    And press "Save"
+    And press "Close"
+    And I switch to the iframe ""
+    And I follow "Activities"
+    Then I should see "Samwise"
+    And I should see "Manual timestamp note"
+    And I should see "07-07-26 (04:37 PM)"

--- a/test/features/bootstrap/FeatureContext.php
+++ b/test/features/bootstrap/FeatureContext.php
@@ -285,6 +285,34 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
         $this->getSession()->evaluateScript($script);
     }
     
+
+    /**
+     * @Given I set hidden field :field to :value
+     */
+    public function iSetHiddenFieldTo($field, $value)
+    {
+        $page = $this->getSession()->getPage();
+        $inputField = $page->find('css', sprintf('input[type="hidden"][name="%s"]', $field));
+
+        if (null === $inputField)
+        {
+            $inputField = $page->find('css', sprintf('input[type="hidden"]#%s', $field));
+        }
+
+        if (null === $inputField)
+        {
+            throw new \InvalidArgumentException(sprintf('Could not find hidden field: "%s"', $field));
+        }
+
+        $script = sprintf(
+            '(function(){ var f = document.getElementsByName(%s)[0] || document.getElementById(%s); if (f) { f.value = %s; } })();',
+            json_encode($field),
+            json_encode($field),
+            json_encode($value)
+        );
+
+        $this->getSession()->executeScript($script);
+    }
     /** Click on the element with the provided xpath query
      *
      * @When I click on the element :locator


### PR DESCRIPTION
## Summary

This PR allows users to manually set the date and time when logging an activity.

It adds manual date and time inputs to the activity modal and persists the selected timestamp when the activity is created. If no valid manual timestamp is provided, the existing default behavior is preserved.

The change is intentionally minimal and keeps the existing flow intact while making sure manually logged activities can reflect their actual occurrence time.

## Motivation

When activities are entered after the fact, using the current timestamp may not accurately reflect when the activity originally occurred.

This is especially relevant for emails that are logged retroactively. In those cases, it is helpful for the recorded activity to reflect the original date and time instead of the time of entry.