### PR TITLE
feat: reorder activity table columns

### DIFF
--- a/modules/candidates/Show.tpl
+++ b/modules/candidates/Show.tpl
@@ -626,9 +626,9 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                 <tr>
                     <th align="left" width="125">Date</th>
                     <th align="left" width="90">Type</th>
-                    <th align="left" width="90">Entered By</th>
                     <th align="left" width="250">Regarding</th>
                     <th align="left">Notes</th>
+                    <th align="left" width="90">Entered By</th>
 <?php if (!$this->isPopup): ?>
                     <th align="left" width="40">Action</th>
 <?php endif; ?>
@@ -638,9 +638,9 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                     <tr class="<?php TemplateUtility::printAlternatingRowClass($rowNumber); ?>">
                         <td align="left" valign="top" id="activityDate<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['dateCreated']) ?></td>
                         <td align="left" valign="top" id="activityType<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
-                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
                         <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes'])); ?></td>
+                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
 <?php if (!$this->isPopup): ?>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('candidates.edit') >= ACCESS_LEVEL_EDIT): ?>

--- a/modules/companies/Show.tpl
+++ b/modules/companies/Show.tpl
@@ -423,10 +423,10 @@ use OpenCATS\UI\QuickActionMenu;
                 <tr>
                     <th align="left" width="125">Date</th>
                     <th align="left" width="90">Type</th>
-                    <th align="left" width="140">Contact</th>
-                    <th align="left" width="90">Entered By</th>
                     <th align="left" width="250">Regarding</th>
+                    <th align="left" width="140">Contact</th>
                     <th align="left">Notes</th>
+                    <th align="left" width="90">Entered By</th>
                     <th align="left" width="40">Action</th>
                 </tr>
 
@@ -434,6 +434,7 @@ use OpenCATS\UI\QuickActionMenu;
                     <tr class="<?php TemplateUtility::printAlternatingRowClass($rowNumber); ?>">
                         <td align="left" valign="top" id="activityDate<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['dateCreated']); ?></td>
                         <td align="left" valign="top" id="activityType<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']); ?></td>
+                        <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']); ?></td>
                         <td align="left" valign="top">
                             <?php if (!empty($activityData['contactID'])): ?>
                                 <a href="<?php echo Template::escapeUrl(CATSUtility::getIndexName() . '?m=contacts&a=show&contactID=' . $activityData['contactID']); ?>">
@@ -443,9 +444,8 @@ use OpenCATS\UI\QuickActionMenu;
                                 <?php $this->_($activityData['contactFullName']); ?>
                             <?php endif; ?>
                         </td>
-                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']); ?></td>
-                        <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']); ?></td>
                         <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(Template::escapeHtml($activityData['notes'])); ?></td>
+                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']); ?></td>
                         <td align="center">
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>
                                 <a href="#" id="editActivity<?php echo Template::escapeAttr($activityData['activityID']); ?>" onclick="Activity_editEntry(<?php echo (int) $activityData['activityID']; ?>, <?php echo (int) $activityData['contactID']; ?>, <?php echo (int) DATA_ITEM_CONTACT; ?>, <?php echo Template::escapeJsAttr($this->sessionCookie); ?>); return false;">

--- a/modules/contacts/Show.tpl
+++ b/modules/contacts/Show.tpl
@@ -277,9 +277,9 @@ use OpenCATS\UI\QuickActionMenu;
                 <tr>
                     <th align="left" width="125">Date</th>
                     <th align="left" width="90">Type</th>
-                    <th align="left" width="90">Entered By</th>
                     <th align="left" width="250">Regarding</th>
                     <th align="left">Notes</th>
+                    <th align="left" width="90">Entered By</th>
                     <th align="left" width="40">Action</th>
                 </tr>
 
@@ -287,9 +287,9 @@ use OpenCATS\UI\QuickActionMenu;
                     <tr class="<?php TemplateUtility::printAlternatingRowClass($rowNumber); ?>">
                         <td align="left" valign="top" id="activityDate<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['dateCreated']) ?></td>
                         <td align="left" valign="top" id="activityType<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
-                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
                         <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes'])); ?></td>
+                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>
                                 <a href="#" id="editActivity<?php echo Template::escapeAttr($activityData['activityID']); ?>" onclick="Activity_editEntry(<?php echo (int) $activityData['activityID']; ?>, <?php echo (int) $this->contactID; ?>, <?php echo (int) DATA_ITEM_CONTACT; ?>, <?php echo Template::escapeJsAttr($this->sessionCookie); ?>); return false;">


### PR DESCRIPTION
## Summary

Reorders the columns in activity tables on detail pages to improve readability.

The previous order placed secondary metadata before the main activity context. This PR moves the "Regarding" column closer to the activity type and moves "Entered By" further to the right.

For company detail pages, the new order is:

Date | Type | Regarding | Contact | Notes | Entered By | Action

For candidate and contact detail pages, which do not have a separate Contact column, the new order is:

Date | Type | Regarding | Notes | Entered By | Action

## Motivation

Activity lists are easier to scan when the primary context appears early in the row. Placing "Regarding" directly after "Type" makes it clearer what the activity refers to before showing notes or audit metadata.

The "Entered By" column is still available, but it is less central to quickly understanding the activity itself, so it now appears closer to the action column.