### PR TITLE
refactor: move activity description escaping to templates

### DIFF
--- a/modules/candidates/AddActivityScheduleEventModal.tpl
+++ b/modules/candidates/AddActivityScheduleEventModal.tpl
@@ -198,7 +198,7 @@
          <?php if (!$this->onlyScheduleEvent): ?>
             <?php if ($this->activityAdded): ?>
                 <?php if (!empty($this->activityDescription)): ?>
-                    <p>An activity entry of type <span class="bold"><?php $this->_($this->activityType); ?></span> has been added with the following note: &quot;<?php echo($this->activityDescription); ?>&quot;.</p>
+                    <p>An activity entry of type <span class="bold"><?php $this->_($this->activityType); ?></span> has been added with the following note: &quot;<?php $this->_($this->activityDescription); ?>&quot;.</p>
                 <?php else: ?>
                     <p>An activity entry of type <span class="bold"><?php $this->_($this->activityType); ?></span> has been added with no notes.</p>
                 <?php endif; ?>

--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -3355,7 +3355,7 @@ class CandidatesUI extends UserInterface
         $this->_template->assign('candidateID', $candidateID);
         $this->_template->assign('regardingID', $regardingID);
         $this->_template->assign('activityAdded', $activityAdded);
-        $this->_template->assign('activityDescription', htmlspecialchars($activityNote, ENT_QUOTES | ENT_SUBSTITUTE, HTML_ENCODING));
+        $this->_template->assign('activityDescription', $activityNote);
         $this->_template->assign('activityType', $activityTypeDescription);
         $this->_template->assign('eventScheduled', $eventScheduled);
         $this->_template->assign('eventHTML', $eventHTML);

--- a/modules/contacts/AddActivityScheduleEventModal.tpl
+++ b/modules/contacts/AddActivityScheduleEventModal.tpl
@@ -161,7 +161,7 @@
         <?php if(!$this->onlyScheduleEvent): ?>
             <?php if ($this->activityAdded): ?>
                 <?php if (!empty($this->activityDescription)): ?>
-                    <p>An activity entry of type <span class="bold"><?php $this->_($this->activityType); ?></span> has been added with the following note: &quot;<?php echo($this->activityDescription); ?>&quot;.</p>
+                    <p>An activity entry of type <span class="bold"><?php $this->_($this->activityType); ?></span> has been added with the following note: &quot;<?php $this->_($this->activityDescription); ?>&quot;.</p>
                 <?php else: ?>
                     <p>An activity entry of type <span class="bold"><?php $this->_($this->activityType); ?></span> has been added with no notes.</p>
                 <?php endif; ?>


### PR DESCRIPTION
This PR moves activity description escaping for activity schedule event modals from the controller layer to the template output layer.

Previously, the contact and candidate activity modal descriptions were escaped before being assigned to the template, while the corresponding templates rendered the assigned value directly. This worked, but mixed presentation escaping into the controller flow and made it easier to accidentally introduce inconsistent escaping behavior.

The controllers now assign the raw activity note to `activityDescription`, and the modal templates escape the value at the output boundary using the existing OpenCATS template escaping helper. This keeps the value escaped exactly once, avoids double escaping and aligns the contact and candidate activity schedule event modals with the preferred template output pattern.

The change is intentionally limited to the contact and candidate activity schedule event modal description flow. It does not change activity creation, request handling, database handling, calendar event behavior or modal behavior.