### PR TITLE
feat: exclude closed jobs from activity references

### DIFF
--- a/lib/Contacts.php
+++ b/lib/Contacts.php
@@ -33,6 +33,7 @@ include_once(LEGACY_ROOT . '/lib/Pager.php');
 include_once(LEGACY_ROOT . '/lib/EmailTemplates.php');
 include_once(LEGACY_ROOT . '/lib/ExtraFields.php');
 include_once(LEGACY_ROOT . '/lib/Calendar.php');
+include_once(LEGACY_ROOT . '/lib/JobOrderStatuses.php');
 
 /**
  *	Contacts Library
@@ -697,6 +698,45 @@ class Contacts
             $this->_db->makeQueryInteger($contactID),
             $this->_db->makeQueryInteger($contactID),
             $this->_siteID
+        );
+
+        return $this->_db->getAllAssoc($sql);
+     }
+
+    /**
+     * Returns an array of non-closed job orders data (jobOrderID, title, companyName)
+     * for the specified contact ID.
+     *
+     * @param integer contact ID
+     * @return array job orders data
+     */
+    public function getNonClosedJobOrdersArray($contactID)
+    {
+        $sql = sprintf(
+            "SELECT
+                joborder.joborder_id AS jobOrderID,
+                joborder.title AS title,
+                company.name AS companyName,
+                IF(joborder.contact_id = %s, 1, 0) AS isAssigned
+            FROM
+                joborder
+            LEFT JOIN company
+                ON joborder.company_id = company.company_id
+            LEFT JOIN contact
+                ON company.company_id = contact.company_id
+            WHERE
+                contact.contact_id = %s
+            AND
+                joborder.site_id = %s
+            AND
+                joborder.status NOT IN %s
+            ORDER BY
+                isAssigned DESC,
+                title ASC",
+            $this->_db->makeQueryInteger($contactID),
+            $this->_db->makeQueryInteger($contactID),
+            $this->_siteID,
+            JobOrderStatuses::getClosedStatusSQL()
         );
 
         return $this->_db->getAllAssoc($sql);

--- a/lib/JobOrderStatuses.php
+++ b/lib/JobOrderStatuses.php
@@ -143,6 +143,22 @@ class JobOrderStatuses
         return $result;
     }
 
+    /**
+     * Returns closed job order statuses in a format for MySQL IN() query
+     */
+    public static function getClosedStatusSQL(){
+        $result = "";
+        $array = self::getAll()['Closed'];
+        foreach($array as $status){
+            $result .= "'".$status."',";
+        }
+        if(strlen($result) > 0){
+            $result = substr($result, 0, strlen($result) - 1);
+            $result = "(".$result.")";
+        }
+        return $result;
+    }
+
     public static function getDefaultStatus(){
         if(defined('JOB_ORDER_STATUS_DEFAULT')){
             return JOB_ORDER_STATUS_DEFAULT;
@@ -151,4 +167,3 @@ class JobOrderStatuses
         }
     }
 }
-

--- a/lib/Pipelines.php
+++ b/lib/Pipelines.php
@@ -31,6 +31,7 @@
  */
 
 include_once(LEGACY_ROOT . '/lib/History.php');
+include_once(LEGACY_ROOT . '/lib/JobOrderStatuses.php');
 
 /**
  *	Pipelines Library
@@ -523,6 +524,77 @@ class Pipelines
             $this->_siteID,
             $this->_siteID,
             $this->_siteID
+        );
+
+        return $this->_db->getAllAssoc($sql);
+    }
+
+    /**
+     * Returns a candidate's non-closed pipeline.
+     *
+     * @param integer candidate ID
+     * @return array pipeline data
+     */
+    public function getNonClosedCandidatePipeline($candidateID)
+    {
+        $sql = sprintf(
+            "SELECT
+                company.company_id AS companyID,
+                company.name AS companyName,
+                joborder.joborder_id AS jobOrderID,
+                joborder.title AS title,
+                joborder.type AS type,
+                joborder.duration AS duration,
+                joborder.rate_max AS maxRate,
+                joborder.status AS jobOrderStatus,
+                joborder.salary AS salary,
+                joborder.is_hot AS isHot,
+                joborder.client_job_id AS clientJobID,
+                DATE_FORMAT(
+                    joborder.start_date, '%%m-%%d-%%y'
+                ) AS start_date,
+                DATE_FORMAT(
+                    joborder.date_created, '%%m-%%d-%%y'
+                ) AS dateCreated,
+                candidate.candidate_id AS candidateID,
+                candidate.email1 AS candidateEmail,
+                candidate_joborder_status.candidate_joborder_status_id AS statusID,
+                candidate_joborder_status.short_description AS status,
+                candidate_joborder.candidate_joborder_id AS candidateJobOrderID,
+                candidate_joborder.rating_value AS ratingValue,
+                owner_user.first_name AS ownerFirstName,
+                owner_user.last_name AS ownerLastName,
+                added_user.first_name AS addedByFirstName,
+                added_user.last_name AS addedByLastName
+            FROM
+                candidate_joborder
+            INNER JOIN candidate
+                ON candidate_joborder.candidate_id = candidate.candidate_id
+            INNER JOIN joborder
+                ON candidate_joborder.joborder_id = joborder.joborder_id
+            INNER JOIN company
+                ON company.company_id = joborder.company_id
+            LEFT JOIN user AS owner_user
+                ON joborder.owner = owner_user.user_id
+            LEFT JOIN user AS added_user
+                ON candidate_joborder.added_by = added_user.user_id
+            INNER JOIN candidate_joborder_status
+                ON candidate_joborder.status = candidate_joborder_status.candidate_joborder_status_id
+            WHERE
+                candidate.candidate_id = %s
+            AND
+                candidate.site_id = %s
+            AND
+                joborder.site_id = %s
+            AND
+                company.site_id = %s
+            AND
+                joborder.status NOT IN %s",
+            $this->_db->makeQueryInteger($candidateID),
+            $this->_siteID,
+            $this->_siteID,
+            $this->_siteID,
+            JobOrderStatuses::getClosedStatusSQL()
         );
 
         return $this->_db->getAllAssoc($sql);

--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -1805,7 +1805,7 @@ class CandidatesUI extends UserInterface
         }
 
         $pipelines = new Pipelines($this->_siteID);
-        $pipelineRS = $pipelines->getCandidatePipeline($candidateID);
+        $pipelineRS = $pipelines->getNonClosedCandidatePipeline($candidateID);
 
         /* Are we in "Only Schedule Event" mode? */
         $onlyScheduleEvent = $this->isChecked('onlyScheduleEvent', $_GET);

--- a/modules/contacts/ContactsUI.php
+++ b/modules/contacts/ContactsUI.php
@@ -1106,7 +1106,7 @@ class ContactsUI extends UserInterface
         $contacts = new Contacts($this->_siteID);
         $contactData = $contacts->get($contactID);
 
-        $regardingRS = $contacts->getJobOrdersArray($contactID);
+        $regardingRS = $contacts->getNonClosedJobOrdersArray($contactID);
 
         $calendar = new Calendar($this->_siteID);
         $calendarEventTypes = $calendar->getAllEventTypes();


### PR DESCRIPTION
## Summary

This PR updates the add activity / schedule event flows for Contacts and Candidates so that the Regarding job reference dropdown excludes job orders from the configured Closed status group.

Instead of only allowing jobs from the Open status group, the filtering now excludes Closed-group statuses. This keeps Pre-Open job orders such as Upcoming and Lead available, while hiding Closed, Canceled or other statuses configured as closed.

The change adds a central closed job order status SQL helper and uses it from the Contact and Candidate activity reference queries.

The existing activity edit AJAX flow is intentionally left unchanged.

## Motivation

When creating new activities, the Regarding dropdown should focus on current job orders that are still relevant for new activity logging. Closed job orders are no longer current references in that context and can make the selection unnecessarily noisy.

This is also related to #361.