### PR TITLE
refactor: replace legacy database result handling

### DIFF
--- a/modules/install/OptionalComponents.php
+++ b/modules/install/OptionalComponents.php
@@ -39,9 +39,9 @@ $optionalComponents['usZipCodes']['removeCode'] = '
     CATSUtility::changeConfigSetting(\'US_ZIPS_ENABLED\', "false");
 ';
 $optionalComponents['usZipCodes']['detectCode'] = '
-    $rs = MySQLQuery(\'SELECT * FROM zipcodes\');
+    $recordSet = MySQLGetAssoc(\'SELECT zipcode FROM zipcodes LIMIT 1\');
 
-    if ($rs && mysqli_fetch_row($rs))
+    if (!empty($recordSet))
     {
         return true;
     }

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -722,7 +722,7 @@ class CATSSchema
                         "UPDATE
                             dashboard_component
                         SET
-                            module_parameters = \'" . mysql_real_escape_string($serializedValue) . "\'
+                            module_parameters = " . $db->makeQueryString($serializedValue) . "
                         WHERE
                             dashboard_component_id = " . $row[\'dashboard_component_id\']
                     );
@@ -849,9 +849,9 @@ class CATSSchema
                 UPDATE system SET disable_version_check = 1;
             ',
             '253' => 'PHP:
-                $rs = $db->query(\'SELECT * FROM zipcodes\');
+                $rs = $db->getAssoc(\'SELECT zipcode FROM zipcodes LIMIT 1\');
 
-                if ($rs && mysql_fetch_row($rs))
+                if (!empty($rs))
                 {
                     $db->query(\'DELETE FROM zipcodes\');
                     $schemaZipcodes = @file_get_contents(\'db/upgrade-zipcodes.sql\');
@@ -1233,7 +1233,7 @@ class CATSSchema
                 $lists = $db->getAllAssoc("SELECT * FROM saved_list");
                 foreach($lists as $list)
                 {
-                    $db->query(sprintf("UPDATE saved_list SET description = \"%s\" WHERE saved_list_id = %s", mysql_real_escape_string(urldecode($list[\'description\'])), $list[\'saved_list_id\']));
+                    $db->query(sprintf("UPDATE saved_list SET description = %s WHERE saved_list_id = %s", $db->makeQueryString(urldecode($list[\'description\'])), $list[\'saved_list_id\']));
                 }
             ',
             '343' => '

--- a/modules/install/ajax/ui.php
+++ b/modules/install/ajax/ui.php
@@ -184,9 +184,11 @@ switch ($action)
         $mailFromAddress = '';
         if (isset($tables['settings']))
         {
-            $rs = MySQLQuery('SELECT value FROM settings WHERE setting = "fromAddress" LIMIT 1');
-            if (mysqli_num_rows($rs) > 0)
-                $mailFromAddress = mysqli_fetch_row($rs);
+            $recordSet = MySQLGetAssoc('SELECT value FROM settings WHERE setting = "fromAddress" LIMIT 1');
+            if (!empty($recordSet))
+            {
+                $mailFromAddress = array($recordSet['value']);
+            }
         }
 
         echo '
@@ -475,15 +477,7 @@ switch ($action)
         echo '<script type="text/javascript">';
 
         /* Detect date format preferences. */
-        $rs = MySQLQuery('SELECT date_format_ddmmyy FROM site', true);
-        if ($rs)
-        {
-            $record = mysqli_fetch_assoc($rs);
-        }
-        else
-        {
-            $record = array();
-        }
+        $record = MySQLGetAssoc('SELECT date_format_ddmmyy FROM site LIMIT 1', true);
 
         if (!isset($record['date_format_ddmmyy']) || $record['date_format_ddmmyy'] == 0)
         {
@@ -629,15 +623,7 @@ switch ($action)
             die();
         }
 
-        $rs = MySQLQuery('SELECT * FROM candidate', true);
-        $fields = array();
-        while ($meta = @mysqli_fetch_field($rs))
-        {
-            if ($meta)
-            {
-                $fields[$meta->name] = true;
-            }
-        }
+        $fields = getInstalledTableFields('candidate');
 
         $catsVersion = '';
 
@@ -817,10 +803,11 @@ switch ($action)
 
         //Check if we need to update from 0.6.0 to 0.7.0
         $tables = array();
-        $result = MySQLQuery(sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME));
-        while ($row = mysqli_fetch_array($result, MYSQLI_NUM))
+        $resultSet = MySQLGetAllAssoc(sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME));
+        foreach ($resultSet as $row)
         {
-            $tables[$row[0]] = true;
+            $tableName = reset($row);
+            $tables[$tableName] = true;
         }
 
         if (!isset($tables['history']))
@@ -909,12 +896,7 @@ switch ($action)
         }
 
         $revision = 0;
-        $rs = MySQLQuery('SELECT * FROM candidate', true);
-        $fields = array();
-        while ($meta = mysqli_fetch_field($rs))
-        {
-            $fields[$meta->name] = true;
-        }
+        $fields = getInstalledTableFields('candidate');
 
         /* Look for more versions here. */
         if (!isset($fields['date_available']))
@@ -1038,18 +1020,18 @@ switch ($action)
         $fromAddress = $_SESSION['fromAddressInstaller'];
 
         // If this is an existing database, just set all the fromAddress settings to new
-        MySQLQuery(sprintf('UPDATE settings SET value = "%s" WHERE setting = "fromAddress"', $fromAddress));
+        $db->query(sprintf('UPDATE settings SET value = %s WHERE setting = "fromAddress"', $db->makeQueryString($fromAddress)));
         // This is a new install, insert a settings value for each site in the database
-        if(mysqli_affected_rows($mySQLConnection) == 0)
+        if ($db->getAffectedRows() == 0)
         {
             // Insert a "fromAddress" = $fromAddress for each site
-            MySQLQuery(sprintf(
+            $db->query(sprintf(
                 'INSERT INTO settings (setting, value, site_id, settings_type) '
-                . 'SELECT "fromAddress", "%s", site_id, 1 FROM site',
-                $fromAddress
+                . 'SELECT "fromAddress", %s, site_id, 1 FROM site',
+                $db->makeQueryString($fromAddress)
             ));
             // Insert a "configured" = 1 setting for each site
-            MySQLQuery(
+            $db->query(
                 'INSERT INTO settings (setting, value, site_id, settings_type) '
                 . 'SELECT "configured", "1", site_id, 1 FROM site'
             );
@@ -1112,8 +1094,10 @@ switch ($action)
         MySQLConnect();
 
         /* Determine if a default user is set. */
-        $rs = MySQLQuery("SELECT * FROM user WHERE user_name = 'admin' AND password = md5('cats')");
-        if ($rs && mysqli_fetch_row($rs))
+        $record = MySQLGetAssoc(
+            "SELECT user_id FROM user WHERE user_name = 'admin' AND password = md5('cats') LIMIT 1"
+        );
+        if (!empty($record))
         {
             //Default user set
             echo '<script type="text/javascript">document.location.href="index.php?defaultlogin=true";</script>';
@@ -1131,7 +1115,7 @@ switch ($action)
 
 function MySQLConnect()
 {
-    global $tables, $mySQLConnection;
+    global $tables, $mySQLConnection, $db;
 
     $mySQLConnection = @mysqli_connect(
         DATABASE_HOST, DATABASE_USER, DATABASE_PASS
@@ -1151,12 +1135,16 @@ function MySQLConnect()
     }
 
 
+    include_once(LEGACY_ROOT . '/lib/DatabaseConnection.php');
+    $db = getInstallerDatabaseConnection();
+
     /* Create an array of all tables in the database. */
     $tables = array();
-    $result = MySQLQuery(sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME));
-    while ($row = mysqli_fetch_row($result))
+    $resultSet = MySQLGetAllAssoc(sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME));
+    foreach ($resultSet as $row)
     {
-        $tables[$row[0]] = true;
+        $tableName = reset($row);
+        $tables[$tableName] = true;
     }
 
     /* Select CATS database. */
@@ -1173,6 +1161,18 @@ function MySQLConnect()
         );
         return false;
     }
+}
+
+function getInstallerDatabaseConnection()
+{
+    global $db;
+
+    if (is_object($db) && method_exists($db, 'query'))
+    {
+        return $db;
+    }
+
+    return DatabaseConnection::getInstance();
 }
 
 function MySQLQuery($query, $ignoreErrors = false)
@@ -1196,6 +1196,44 @@ function MySQLQuery($query, $ignoreErrors = false)
     }
 
     return $queryResult;
+}
+
+function getInstalledTableFields($table)
+{
+    $fields = array();
+    $fieldMeta = MySQLGetAllAssoc(sprintf('SHOW COLUMNS FROM %s', $table), true);
+    foreach ($fieldMeta as $meta)
+    {
+        if (isset($meta['Field']))
+        {
+            $fields[$meta['Field']] = true;
+        }
+    }
+    return $fields;
+}
+
+function MySQLGetAssoc($query, $ignoreErrors = false)
+{
+    global $db;
+
+    if (!$db->query($query, $ignoreErrors))
+    {
+        return array();
+    }
+
+    return $db->getAssoc();
+}
+
+function MySQLGetAllAssoc($query, $ignoreErrors = false)
+{
+    global $db;
+
+    if (!$db->query($query, $ignoreErrors))
+    {
+        return array();
+    }
+
+    return $db->getAllAssoc();
 }
 
 function MySQLQueryMultiple($SQLData, $delimiter = ';')

--- a/modules/install/backupDB.php
+++ b/modules/install/backupDB.php
@@ -75,16 +75,12 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
     $len = 0;
     $fileNumber = 0;
 
-    $connection = $db->getConnection();
-
     $text = '';
 
-    $result = mysqli_query($connection,
-        sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME)
-    );
-    while ($row = mysqli_fetch_array($result, MYSQLI_NUM))
+    $resultSet = $db->getAllAssoc(sprintf("SHOW TABLES FROM `%s`", DATABASE_NAME));
+    foreach ($resultSet as $row)
     {
-        $tables[] = $row[0];
+        $tables[] = reset($row);
     }
     
     if ($splitFiles) $fh = fopen($file . '.' . $fileNumber, 'w');
@@ -107,13 +103,10 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
 
         $text .= 'DROP TABLE IF EXISTS `' . $table . '`((ENDOFQUERY))'."\n";
         $sql = 'SHOW CREATE TABLE ' . $table;
-        $rs = mysqli_query($connection, $sql);
-        if ($rs)
+        $row = $db->getAssoc($sql);
+        if (!empty($row))
         {
-            if ($row = mysqli_fetch_assoc($rs))
-            {
-                $text .= $row['Create Table'] . "((ENDOFQUERY))\n\n";
-            }
+            $text .= $row['Create Table'] . "((ENDOFQUERY))\n\n";
         }
 
         if ($table == 'word_verification') continue;
@@ -131,14 +124,14 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
 
         $isSiteIdColumn = false;
         $sql = sprintf("SHOW COLUMNS FROM %s", $table);
-        $rs = mysqli_query($connection, $sql);
-        while ($recordSet = mysqli_fetch_assoc($rs))    
+        $columnRecordSet = $db->getAllAssoc($sql);
+        foreach ($columnRecordSet as $recordSet)
         {
             if ($recordSet['Field'] == 'site_id')
             {
                 $isSiteIdColumn = true;
             }
-        }    
+        }
         
         if ($isSiteIdColumn)
         {
@@ -149,10 +142,16 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
             $sql = 'SELECT * FROM ' . $table . '';
         }
 
-        $rs = mysqli_query($sql, $connection);
         $index = 0;
-        while ($recordSet = mysqli_fetch_assoc($rs))
+        $db->query($sql);
+        while (true)
         {
+            $recordSet = $db->getAssoc();
+            if (empty($recordSet))
+            {
+                break;
+            }
+
             $continue = true;
 
             if (isset($recordSet['site_id']))
@@ -227,7 +226,7 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
                 $i = 0;
                 foreach ($recordSet as $field)
                 {
-                    $text .= "'".mysqli_real_escape_string($connection, $field)."'";
+                    $text .= $db->makeQueryString($field);
                     $i++;
                     if ($i != count($recordSet))
                     {

--- a/modules/settings/ajax/backup.php
+++ b/modules/settings/ajax/backup.php
@@ -247,13 +247,19 @@ if ($action == 'backup')
             site_id = %s",
         $siteID
     );
-    $queryResult = mysqli_query($db, $sql);
-    $totalAttachments = mysqli_num_rows($queryResult);
+    $db->query($sql);
+    $totalAttachments = $db->getNumRows();
 
     /* Add each attachment to the zip file. */
     $attachmentCount = 0;
-    while ($row = mysqli_fetch_assoc($queryResult))
+    while (true)
     {
+        $row = $db->getAssoc();
+        if (empty($row))
+        {
+            break;
+        }
+
         ++$attachmentCount;
         $relativePath = sprintf(
             'attachments/%s/%s',

--- a/scripts/makeBackup.php
+++ b/scripts/makeBackup.php
@@ -243,12 +243,18 @@ function dumpAttachments($db, $directory, $siteID)
         $siteID
     );
 
-    $queryResult = mysqli_query($db, $sql);
-    $totalAttachments = mysqli_num_rows($queryResult);
+    $db->query($sql);
+    $totalAttachments = $db->getNumRows();
 
     /* Add each attachment to the zip file. */
-    while ($row = mysqli_fetch_assoc($queryResult))
+    while (true)
     {
+        $row = $db->getAssoc();
+        if (empty($row))
+        {
+            break;
+        }
+
         $relativePath = sprintf(
             'attachments/%s/%s',
             $row['directory_name'],

--- a/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
+++ b/src/OpenCATS/Tests/IntegrationTests/DatabaseConnectionTest.php
@@ -198,6 +198,121 @@ class DatabaseConnectionTest extends DatabaseTestCase
             'DELETE query should succeed'
             );
     }
+
+    function testGetAssocWithoutQueryUsesActiveResultSetAndAdvances()
+    {
+        $db = DatabaseConnection::getInstance();
+
+        $db->query('INSERT INTO installtest (id) VALUES (101), (102)');
+        $db->query('SELECT id FROM installtest ORDER BY id ASC');
+
+        $firstRow = $db->getAssoc();
+        $secondRow = $db->getAssoc();
+        $thirdRow = $db->getAssoc();
+
+        $this->assertSame(
+            array('id' => '101'),
+            $firstRow,
+            'First row should be returned from the active result set.'
+        );
+        $this->assertSame(
+            array('id' => '102'),
+            $secondRow,
+            'Second call should advance to the next row in the active result set.'
+        );
+        $this->assertSame(
+            array(),
+            $thirdRow,
+            'Exhausted active result sets should return an empty array.'
+        );
+    }
+
+    function testGetAssocWithoutQuerySupportsCountRowAfterQuery()
+    {
+        $db = DatabaseConnection::getInstance();
+
+        $db->query('INSERT INTO installtest (id) VALUES (201), (202), (203)');
+        $db->query('SELECT COUNT(*) AS totalRows FROM installtest');
+
+        $countRow = $db->getAssoc();
+
+        $this->assertSame(
+            array('totalRows' => '3'),
+            $countRow,
+            'No-argument getAssoc() should read the count-like row from the active result set.'
+        );
+    }
+
+    function testGetNumRowsReturnsRowCountForActiveSelectResult()
+    {
+        $db = DatabaseConnection::getInstance();
+
+        $db->query('INSERT INTO installtest (id) VALUES (301), (302), (303)');
+        $db->query('SELECT id FROM installtest ORDER BY id ASC');
+
+        $this->assertSame(
+            3,
+            $db->getNumRows(),
+            'getNumRows() should return row count from the active SELECT result set.'
+        );
+    }
+
+    function testGetAffectedRowsReflectsInsertUpdateAndDelete()
+    {
+        $db = DatabaseConnection::getInstance();
+
+        $db->query('INSERT INTO installtest (id) VALUES (401), (402)');
+        $this->assertSame(
+            2,
+            $db->getAffectedRows(),
+            'getAffectedRows() should return inserted row count.'
+        );
+
+        $db->query('UPDATE installtest SET id = id + 1000 WHERE id IN (401, 402)');
+        $this->assertSame(
+            2,
+            $db->getAffectedRows(),
+            'getAffectedRows() should return updated row count.'
+        );
+
+        $db->query('DELETE FROM installtest WHERE id IN (1401, 1402)');
+        $this->assertSame(
+            2,
+            $db->getAffectedRows(),
+            'getAffectedRows() should return deleted row count.'
+        );
+    }
+
+    function testGetLastInsertIDReturnsAutoIncrementValue()
+    {
+        $db = DatabaseConnection::getInstance();
+
+        $db->query(
+            'CREATE TABLE test_autoincrement ('
+            . 'id INT NOT NULL AUTO_INCREMENT, '
+            . 'label VARCHAR(32) NOT NULL, '
+            . 'PRIMARY KEY (id)'
+            . ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
+        );
+
+        $db->query("INSERT INTO test_autoincrement (label) VALUES ('first row')");
+        $firstInsertId = $db->getLastInsertID();
+
+        $db->query("INSERT INTO test_autoincrement (label) VALUES ('second row')");
+        $secondInsertId = $db->getLastInsertID();
+
+        $this->assertSame(
+            1,
+            (int) $firstInsertId,
+            'First insert should return auto-increment ID 1.'
+        );
+        $this->assertSame(
+            2,
+            (int) $secondInsertId,
+            'Second insert should return auto-increment ID 2.'
+        );
+    }
+
 }
 
 ?>


### PR DESCRIPTION
This PR removes obsolete legacy MySQL calls and reduces direct mysqli result handling in selected database-related areas by routing them through the existing DatabaseConnection API.

The install schema no longer uses obsolete mysql_* calls, and install-module database result handling now relies more consistently on the existing database helpers. Installer settings writes were also adjusted to use DatabaseConnection query execution and escaping consistently.

Backup-related database access in settings and script code is routed through the existing connection handling while preserving row-by-row processing where appropriate.

Database tests were extended to cover the normalized query handling patterns used by these changes, especially calling getAssoc() after a prior query(), iterating over the active result set, reading active result row counts, checking affected rows and retrieving inserted IDs.