### PR TITLE
fix: use NULL for missing calendar event job order references

### DIFF
--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -123,7 +123,7 @@ CREATE TABLE `calendar_event` (
   `date_created` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   `date_modified` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   `site_id` int(11) NOT NULL DEFAULT '0',
-  `joborder_id` int(11) NOT NULL DEFAULT '-1',
+  `joborder_id` int(11) DEFAULT NULL,
   `description` text COLLATE utf8_unicode_ci,
   `duration` int(11) NOT NULL DEFAULT '60',
   `reminder_enabled` int(1) NOT NULL DEFAULT '0',

--- a/lib/Calendar.php
+++ b/lib/Calendar.php
@@ -308,8 +308,8 @@ class Calendar
      *                if none.
      * @param flag Data Item type flag corresponding with $dataItemID, or -1
      *             if none.
-     * @param integer Job Order ID with which to associate this event, or -1
-     *                if none.
+     * @param integer|null Job Order ID with which to associate this event, or
+     *                     NULL if none.
      * @param string Short event title.
      * @param integer Event duration in minutes.
      * @param boolean Enable reminders?
@@ -325,6 +325,15 @@ class Calendar
         $reminderEnabled, $reminderEmail, $reminderTime, $isPublic,
         $timeZoneOffset)
     {
+        if ($jobOrderID === null)
+        {
+            $jobOrderIDSQL = 'NULL';
+        }
+        else
+        {
+            $jobOrderIDSQL = $this->_db->makeQueryInteger($jobOrderID);
+        }
+
         $sql = sprintf(
             "INSERT INTO calendar_event (
                 type,
@@ -372,7 +381,7 @@ class Calendar
             $this->_db->makeQueryInteger($enteredBy),
             $this->_db->makeQueryInteger($dataItemID),
             $this->_db->makeQueryInteger($dataItemType),
-            $this->_db->makeQueryInteger($jobOrderID),
+            $jobOrderIDSQL,
             $this->_siteID,
             $this->_db->makeQueryString($title),
             $this->_db->makeQueryInteger($duration),
@@ -403,8 +412,8 @@ class Calendar
      *                if none.
      * @param flag Data Item type flag corresponding with $dataItemID, or -1
      *             if none.
-     * @param integer Job Order ID with which to associate this event, or -1
-     *                if none.
+     * @param integer|null Job Order ID with which to associate this event, or
+     *                     NULL if none.
      * @param string Short event title.
      * @param integer Event duration in minutes.
      * @param boolean Enable reminders?
@@ -420,6 +429,15 @@ class Calendar
         $reminderEnabled, $reminderEmail, $reminderTime, $isPublic,
         $timeZoneOffset)
     {
+        if ($jobOrderID === null)
+        {
+            $jobOrderIDSQL = 'NULL';
+        }
+        else
+        {
+            $jobOrderIDSQL = $this->_db->makeQueryInteger($jobOrderID);
+        }
+
         $sql = sprintf(
             "UPDATE
                 calendar_event
@@ -449,7 +467,7 @@ class Calendar
             ($allDay ? '1' : '0'),
             $this->_db->makeQueryInteger($dataItemID),
             $this->_db->makeQueryInteger($dataItemType),
-            $this->_db->makeQueryInteger($jobOrderID),
+            $jobOrderIDSQL,
             $this->_db->makeQueryString($title),
             $this->_db->makeQueryInteger($duration),
             ($reminderEnabled ? '1' : '0'),

--- a/lib/JobOrders.php
+++ b/lib/JobOrders.php
@@ -288,6 +288,21 @@ class JobOrders
         $history = new History($this->_siteID);
         $history->storeHistoryDeleted(DATA_ITEM_JOBORDER, $jobOrderID);
 
+        /* Clear calendar event associations for this job order. */
+        $sql = sprintf(
+            "UPDATE
+                calendar_event
+            SET
+                joborder_id = NULL
+            WHERE
+                joborder_id = %s
+            AND
+                site_id = %s",
+            $this->_db->makeQueryInteger($jobOrderID),
+            $this->_siteID
+        );
+        $this->_db->query($sql);
+
         /* Delete pipeline entries from candidate_joborder. */
         $sql = sprintf(
             "DELETE FROM

--- a/modules/calendar/CalendarUI.php
+++ b/modules/calendar/CalendarUI.php
@@ -472,7 +472,7 @@ class CalendarUI extends UserInterface
 
         $calendar = new Calendar($this->_siteID);
         $eventID = $calendar->addEvent(
-            $type, $date, $description, $allDay, $this->_userID, -1, -1, -1,
+            $type, $date, $description, $allDay, $this->_userID, -1, -1, null,
             $title, $duration, $reminderEnabled, $reminderEmail, $reminderTime,
             $publicEntry, $timeZoneOffset
         );
@@ -559,7 +559,7 @@ class CalendarUI extends UserInterface
         }
         else
         {
-            $jobOrderID   = 'NULL';
+            $jobOrderID   = null;
         }
 
         /* Bail out if we received an invalid date. */
@@ -676,7 +676,7 @@ class CalendarUI extends UserInterface
 
         /* Update the event. */
         if (!$calendar->updateEvent($eventID, $type, $date, $description,
-            $allDay, $dataItemID, $dataItemType, 'NULL', $title, $duration,
+            $allDay, $dataItemID, $dataItemType, $jobOrderID, $title, $duration,
             $reminderEnabled, $reminderEmail, $reminderTime, $publicEntry,
             $_SESSION['CATS']->getTimeZoneOffset()))
         {

--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -3329,7 +3329,7 @@ class CandidatesUI extends UserInterface
             }
             else
             {
-                $eventJobOrderID = -1;
+                $eventJobOrderID = null;
             }
 
             $calendar = new Calendar($this->_siteID);

--- a/modules/contacts/ContactsUI.php
+++ b/modules/contacts/ContactsUI.php
@@ -1539,7 +1539,7 @@ class ContactsUI extends UserInterface
             }
             else
             {
-                $eventJobOrderID = -1;
+                $eventJobOrderID = null;
             }
 
             $calendar = new Calendar($this->_siteID);

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1498,6 +1498,25 @@ class CATSSchema
                 ALTER TABLE `joborder`
                 CHANGE `state` `state` VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
             ',
+            '379' => '
+                ALTER TABLE `calendar_event` MODIFY `joborder_id` int(11) NULL DEFAULT NULL;
+
+                UPDATE `calendar_event`
+                SET `joborder_id` = NULL
+                WHERE `joborder_id` = -1;
+
+                UPDATE
+                    `calendar_event` AS `ce`
+                LEFT JOIN
+                    `joborder` AS `jo` ON
+                        `ce`.`joborder_id` = `jo`.`joborder_id` AND
+                        `ce`.`site_id` = `jo`.`site_id`
+                SET
+                    `ce`.`joborder_id` = NULL
+                WHERE
+                    `ce`.`joborder_id` IS NOT NULL AND
+                    `jo`.`joborder_id` IS NULL;
+            ',
 
         );
     }


### PR DESCRIPTION
PR #704 changed optional activity job order references to use NULL instead of the legacy -1 sentinel. Calendar events have the same optional job order relationship, but `calendar_event.joborder_id` still used `-1` for missing job order references.

This updates `calendar_event.joborder_id` so missing job order references are represented as NULL consistently. The base schema now allows NULL and defaults to NULL and the update migration converts existing `-1` values as well as orphaned non-NULL job order references to NULL.

The runtime write paths were updated accordingly. Calendar event creation and updates now pass PHP null when no job order is associated, and `Calendar::addEvent()` / `Calendar::updateEvent()` write SQL NULL for that case. Deleting a job order now clears related calendar event job order references by setting them to NULL.

The scope is intentionally limited to `calendar_event.joborder_id`. Other legacy `-1` sentinels, such as `calendar_event.data_item_id`, `calendar_event.data_item_type`, activity input sentinels, and filter parameters where `-1` has a different meaning, are left unchanged.