### PR TITLE
chore: remove obsolete candidate job order status type tables

### DIFF
--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -304,18 +304,6 @@ CREATE TABLE `candidate_joborder_status_history` (
 
 /*Data for the table `candidate_joborder_status_history` */
 
-/*Table structure for table `candidate_jobordrer_status_type` */
-
-CREATE TABLE `candidate_jobordrer_status_type` (
-  `candidate_status_type_id` int(11) NOT NULL DEFAULT '0',
-  `short_description` varchar(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `can_be_scheduled` int(1) NOT NULL DEFAULT '0',
-  PRIMARY KEY (`candidate_status_type_id`),
-  KEY `IDX_short_description` (`short_description`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-
-/*Data for the table `candidate_jobordrer_status_type` */
-
 /*Table structure for table `candidate_source` */
 
 CREATE TABLE `candidate_source` (

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1661,6 +1661,10 @@ class CATSSchema
                 include_once(\'modules/install/scripts/384.php\');
                 update_384($db);
             ',
+            '385' => '
+                DROP TABLE IF EXISTS `candidate_jobordrer_status_type`;
+                DROP TABLE IF EXISTS `candidate_joborder_status_type`;
+            ',
 
         );
     }

--- a/modules/install/backupDB.php
+++ b/modules/install/backupDB.php
@@ -98,7 +98,6 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
         if ($table == 'address_parser_failures') continue;
         if ($table == 'admin_user') continue;
         if ($table == 'admin_user_login') continue;
-        if ($table == 'candidate_joborder_status_type') continue;
         if ($table == 'timecard_user') continue;
 
         $text .= 'DROP TABLE IF EXISTS `' . $table . '`((ENDOFQUERY))'."\n";


### PR DESCRIPTION
This removes obsolete candidate job order status type table handling from the current schema and install backup flow.

The misspelled `candidate_jobordrer_status_type` table is no longer created by the schema snapshot. A new install schema step drops this table and also keeps a defensive cleanup for the historically referenced `candidate_joborder_status_type` name, so existing installations are cleaned up during schema updates if either legacy table is present.

The dedicated backup exclusion for `candidate_joborder_status_type` is removed as well. Since this legacy table name is now covered by the install schema cleanup path, it no longer needs to be preserved as a special case in database backups.