### PR TITLE
chore: add Behat JUnit reports to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
           docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/phpunit --log-junit /var/www/public/reports/integration-report.xml src/OpenCATS/Tests/IntegrationTests
 
           echo "Running Behat Suites..."
-          docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/behat -v -c ./test/behat.yml --suite="default" --format=progress
-          docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/behat -v -c ./test/behat.yml --suite="security" --format=progress
+          docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/behat -v -c ./test/behat.yml --suite="default" --format=progress --out=std --format=junit --out=reports/behat-default
+          docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php ./vendor/bin/behat -v -c ./test/behat.yml --suite="security" --format=progress --out=std --format=junit --out=reports/behat-security
           # continue-on-error: true
 
       - name: Docker Diagnostics


### PR DESCRIPTION
This PR updates the CI Behat commands to generate JUnit XML reports in addition to the existing progress output.

The CI workflow already creates Behat report directories and publishes XML reports from `reports/**/*.xml`, but the Behat jobs only emitted console progress output. With this change, the default and security Behat suites keep writing progress output to the CI log while also writing JUnit reports to their existing report directories.