### PR TITLE
refactor: run security visibility tests without JavaScript

### DIFF
--- a/test/features/moduleMainPagesSecurity.feature
+++ b/test/features/moduleMainPagesSecurity.feature
@@ -5,7 +5,7 @@ Feature: Access Level to objects check - main pages
   
   ######## DASHBOARD(HOME) #######
 
-  @javascript @dashboard
+  @dashboard
   Scenario Outline: Dashboard module visibility
     Given I am logged in with <accessLevel> access level
     And I am on "/index.php?m=home"
@@ -32,7 +32,7 @@ Feature: Access Level to objects check - main pages
      
   ####### ACTIVITIES #######
     
-  @javascript @activities
+  @activities
   Scenario Outline: Activities module visibility
     Given I am logged in with <accessLevel> access level
     And I am on "/index.php?m=activity"
@@ -64,7 +64,7 @@ Feature: Access Level to objects check - main pages
      
   ####### JOB ORDERS #######
     
-  @javascript @joborders
+  @joborders
   Scenario Outline: Job Orders module visibility
     Given I am logged in with <accessLevel> access level
     And I am on "/index.php?m=joborders"
@@ -98,7 +98,7 @@ Feature: Access Level to objects check - main pages
      
   ####### CANDIDATES #######
      
-  @javascript @candidates
+  @candidates
   Scenario Outline: Candidates module visibility
     Given I am logged in with <accessLevel> access level
     And I am on "/index.php?m=candidates"
@@ -134,7 +134,7 @@ Feature: Access Level to objects check - main pages
 
     ####### COMPANIES #######
     
-    @javascript @companies
+    @companies
     Scenario Outline: Companies module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=companies"
@@ -167,7 +167,7 @@ Feature: Access Level to objects check - main pages
      
    ####### CONTACTS #######
      
-   @javascript @contacts
+   @contacts
    Scenario Outline: Contacts module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=contacts"
@@ -201,7 +201,7 @@ Feature: Access Level to objects check - main pages
      
      ####### LISTS #######
      
-    @javascript @lists
+    @lists
     Scenario Outline: Lists module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=lists"
@@ -227,7 +227,7 @@ Feature: Access Level to objects check - main pages
      
        ####### REPORTS #######
   
-  @javascript @reports
+  @reports
     Scenario Outline: Reports module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=reports"
@@ -257,7 +257,7 @@ Feature: Access Level to objects check - main pages
      
 ####### SETTINGS #######  
 
-@javascript @settings
+@settings
     Scenario Outline: Settings module visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=settings"

--- a/test/features/moduleSubPagesSecurity.feature
+++ b/test/features/moduleSubPagesSecurity.feature
@@ -50,7 +50,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
   
   ####### CANDIDATES #######
   
-   @javascript @candidates
+   @candidates
    Scenario Outline: Candidate Show page visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=candidates"
@@ -93,7 +93,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
      
     ####### COMPANIES #######
 
-    @javascript @companies
+    @companies
     Scenario Outline: Company Show page visibility for disabled level
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=home"
@@ -119,7 +119,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
      | accessLevel | addCompany  | searchCompany  | quickSearch | actionMenu | addAttachment | viewHistory | editCompany   | deleteCompany   | addJobOrder | addContact | editJobOrder | editContact | deleteAttachment | sendEmail |
      | DISABLED    | not see     | not see        | not         | not        | not see       | not see     | not see       | not see         | not see     | not see    | not          | not         | not              | not       |
    
-    @javascript @companies
+    @companies
     Scenario Outline: Company Show page visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=home&a=quickSearch&quickSearchFor=google"
@@ -153,7 +153,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
      
   ####### CONTACTS #######
   
-  @javascript @contacts
+  @contacts
     Scenario Outline: Contacts Show page visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=contacts"
@@ -187,7 +187,7 @@ Feature: Access Level to objects check - sub pages (show, ...)
      
    ####### LISTS #######
        
-   @javascript @lists
+   @lists
    Scenario Outline: Lists Show page visibility
      Given I am logged in with <accessLevel> access level
      And I am on "/index.php?m=lists"


### PR DESCRIPTION
This PR removes unnecessary `@javascript` tags from security visibility Behat scenarios that only verify server-rendered page content and access-level visibility.

The `@javascript` tag is intentionally kept for `Calendar module visibility` and `Job Order Show page visibility`, because validation showed that these scenario outlines still require the JavaScript/Selenium session.

This keeps the security visibility coverage unchanged while allowing most of these scenarios to run through the faster non-JavaScript Behat session.