### PR TITLE
chore: add PR title validation

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,32 @@
+name: Pull Request Title Validation
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  validate-title:
+    name: Validate Pull Request Title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate semantic pull request title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+            docs
+            feat
+            fix
+            refactor
+            security
+            test
+          disallowScopes: |
+            .+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to OpenCATS
+
+## Pull Request Title Format
+
+Pull request titles must follow this format:
+
+`type: description`
+
+Allowed types are `chore`, `docs`, `feat`, `fix`, `refactor`, `security` and `test`.
+
+Scopes are currently not allowed. For example, `fix: correct login redirect` is valid but `fix(auth): correct login redirect` is not.


### PR DESCRIPTION
This adds a GitHub Actions workflow that validates pull request titles against a small Conventional Commits type set.

Allowed pull request title types are `chore`, `docs`, `feat`, `fix`, `refactor`, `security` and `test`. Scopes are intentionally disallowed for now, so titles like `fix: correct login redirect` are accepted while titles like `fix(auth): correct login redirect` are rejected.

This also adds a concise `CONTRIBUTING.md` file documenting the required pull request title format for contributors.