### PR TITLE
refactor: reorder activity data item columns

### DIFF
--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -27,8 +27,8 @@ INSERT INTO `access_level` (`access_level_id`, `short_description`, `long_descri
 
 CREATE TABLE `activity` (
   `activity_id` INT(11) NOT NULL AUTO_INCREMENT,
-  `data_item_id` INT(11) NOT NULL DEFAULT '0',
   `data_item_type` INT(11) NOT NULL DEFAULT '0',
+  `data_item_id` INT(11) NOT NULL DEFAULT '0',
   `joborder_id` INT(11),
   `site_id` INT(11) NOT NULL DEFAULT '0',
   `entered_by` INT(11) NOT NULL DEFAULT '0',

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1805,6 +1805,11 @@ class CATSSchema
                 ALTER TABLE `xml_feeds` MODIFY `description` VARCHAR(255);
                 ALTER TABLE `xml_feeds` MODIFY `website` VARCHAR(255);
             ',
+            '388' => '
+                ALTER TABLE `activity`
+                MODIFY COLUMN `data_item_type` int(11) NOT NULL DEFAULT \'0\'
+                AFTER `activity_id`;
+            ',
 
         );
     }

--- a/test/data/securityTests.sql
+++ b/test/data/securityTests.sql
@@ -49,10 +49,10 @@ VALUES
 (60001, 60001, 100, 20000, 1, '2016-08-10 14:51:51');
 
 INSERT INTO `activity`
-(`activity_id`, `data_item_id`, `data_item_type`, `joborder_id`, `site_id`, `entered_by`, `date_created`, `type`, `notes`, `date_modified`)
+(`activity_id`, `data_item_type`, `data_item_id`, `joborder_id`, `site_id`, `entered_by`, `date_created`, `type`, `notes`, `date_modified`)
 VALUES
-(70001, 20000, 100, 40001, 1, 1, '2016-08-10 14:48:57', 400, 'Added candidate to job order.', '2016-08-10 14:48:57'),
-(70002, 30001, 300, -1, 1, 1, '2016-08-10 15:04:48', 100, '', '2016-08-10 15:04:48');
+(70001, 100, 20000, 40001, 1, 1, '2016-08-10 14:48:57', 400, 'Added candidate to job order.', '2016-08-10 14:48:57'),
+(70002, 300, 30001, -1, 1, 1, '2016-08-10 15:04:48', 100, '', '2016-08-10 15:04:48');
 
 INSERT INTO `attachment`
 (`attachment_id`, `data_item_id`, `data_item_type`, `site_id`, `title`, `original_filename`, `stored_filename`, `content_type`, `resume`, `text`, `date_created`, `date_modified`, `profile_image`, `directory_name`, `md5_sum`, `file_size_kb`, `md5_sum_text`)


### PR DESCRIPTION
This PR reorders the `activity` table columns so that `data_item_type` appears before `data_item_id`.

The previous physical column order placed `data_item_id` before `data_item_type`, even though the ID is interpreted in the context of the type. The existing `IDX_type_id` index already uses the more logical order of `data_item_type, data_item_id`, so this change aligns the table definition with that structure.

For new installations, the base schema now defines `activity.data_item_type` before `activity.data_item_id`. The related security test fixture was updated to keep the explicit `INSERT INTO activity (...)` column order and corresponding values consistent with the schema.

For existing installations, a new install schema migration was added to move `activity.data_item_type` directly after `activity_id`. The migration only changes the physical column position and does not alter data, indexes, column types, defaults, nullability or unrelated schema objects.