### PR TITLE
feat: make contact title optional

### DIFF
--- a/modules/contacts/Add.tpl
+++ b/modules/contacts/Add.tpl
@@ -63,7 +63,7 @@
                                         <label id="titleLabel" for="title">Title:</label>
                                     </td>
                                     <td class="tdData">
-                                        <input type="text" name="title" id="title" class="inputbox" style="width: 150px" />&nbsp;*
+                                        <input type="text" name="title" id="title" class="inputbox" style="width: 150px" />
                                     </td>
                                 </tr>
 

--- a/modules/contacts/ContactsUI.php
+++ b/modules/contacts/ContactsUI.php
@@ -546,7 +546,7 @@ class ContactsUI extends UserInterface
         $departmentsCSV = $this->getTrimmedInput('departmentsCSV', $_POST);
 
         /* Bail out if any of the required fields are empty. */
-        if (empty($firstName) || empty($lastName) || empty($title))
+        if (empty($firstName) || empty($lastName))
         {
             CommonErrors::fatal(COMMONERROR_MISSINGFIELDS, $this, 'Required fields are missing.');
         }
@@ -835,7 +835,7 @@ class ContactsUI extends UserInterface
         $departmentsCSV = $this->getTrimmedInput('departmentsCSV', $_POST);
 
         /* Bail out if any of the required fields are empty. */
-        if (empty($firstName) || empty($lastName) || empty($title))
+        if (empty($firstName) || empty($lastName))
         {
             CommonErrors::fatal(COMMONERROR_MISSINGFIELDS, $this, 'Required fields are missing.');
         }

--- a/modules/contacts/Edit.tpl
+++ b/modules/contacts/Edit.tpl
@@ -66,7 +66,7 @@
                                         <label id="titleLabel" for="title">Title:</label>
                                     </td>
                                     <td class="tdData">
-                                        <input type="text" name="title" id="title" value="<?php $this->_($this->data['title']); ?>" class="inputbox" style="width: 150px" />&nbsp;*
+                                        <input type="text" name="title" id="title" value="<?php $this->_($this->data['title']); ?>" class="inputbox" style="width: 150px" />
                                     </td>
                                 </tr>
 

--- a/modules/contacts/validator.js
+++ b/modules/contacts/validator.js
@@ -15,7 +15,6 @@ function checkAddForm(form)
     errorMessage += checkFirstName();
     errorMessage += checkLastName();
     errorMessage += checkCompany();
-    errorMessage += checkTitle();
 
     if (errorMessage != "")
     {
@@ -33,7 +32,6 @@ function checkEditForm(form)
     errorMessage += checkFirstName();
     errorMessage += checkLastName();
     errorMessage += checkCompany();
-    errorMessage += checkTitle();
 
     if (errorMessage != "")
     {
@@ -124,26 +122,6 @@ function checkCompany()
     if (isNaN(fieldValue) || fieldValue <= 0)
     {
         errorMessage = "    - You must select a company.\n";
-
-        fieldLabel.style.color = "#ff0000";
-    }
-    else
-    {
-        fieldLabel.style.color = "#000";
-    }
-
-    return errorMessage;
-}
-
-function checkTitle()
-{
-    var errorMessage = "";
-
-    fieldValue = document.getElementById("title").value;
-    fieldLabel = document.getElementById("titleLabel");
-    if (fieldValue == "")
-    {
-        errorMessage = "    - You must enter a title.\n";
 
         fieldLabel.style.color = "#ff0000";
     }


### PR DESCRIPTION
## Summary

This PR makes the contact title field optional when creating or editing contacts.

The server-side validation no longer requires a contact title, while first name and last name remain required as before. The add and edit contact forms were also updated so the title field is no longer marked as mandatory and the contact form validation no longer blocks submissions with an empty title.

## Motivation

Contact titles are not always known when adding or updating a contact.

Previously, users had to enter a placeholder value just to save the contact. With this change, contacts can be saved without a title when that information is unknown, while still allowing a title to be entered whenever it is available.