### PR TITLE
refactor: separate activity occurrence dates from creation dates

### DIFF
--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE `activity` (
   `joborder_id` int(11) DEFAULT NULL,
   `site_id` int(11) NOT NULL DEFAULT '0',
   `entered_by` int(11) NOT NULL DEFAULT '0',
+  `date_occurred` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   `date_created` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   `type` int(11) NOT NULL DEFAULT '0',
   `notes` text COLLATE utf8_unicode_ci,
@@ -51,10 +52,13 @@ CREATE TABLE `activity` (
   KEY `IDX_type_id` (`data_item_type`,`data_item_id`),
   KEY `IDX_joborder_id` (`joborder_id`),
   KEY `IDX_date_created` (`date_created`),
+  KEY `IDX_date_occurred` (`date_occurred`),
   KEY `IDX_date_modified` (`date_modified`),
   KEY `IDX_data_item_id_type_site` (`site_id`,`data_item_id`,`data_item_type`),
   KEY `IDX_site_created` (`site_id`,`date_created`),
-  KEY `IDX_activity_site_type_created_job` (`site_id`,`data_item_type`,`date_created`,`entered_by`,`joborder_id`)
+  KEY `IDX_site_occurred` (`site_id`,`date_occurred`),
+  KEY `IDX_activity_site_type_created_job` (`site_id`,`data_item_type`,`date_created`,`entered_by`,`joborder_id`),
+  KEY `IDX_activity_site_type_occurred_job` (`site_id`,`data_item_type`,`date_occurred`,`entered_by`,`joborder_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `activity` */

--- a/lib/ActivityEntries.php
+++ b/lib/ActivityEntries.php
@@ -82,25 +82,25 @@ class ActivityEntries
      * @param string Activity notes.
      * @param integer Entered-by user ID.
      * @param integer Job Order ID; -1 for general (stored as NULL).
-     * @param string Date created timestamp (YYYY-MM-DD HH:MM:SS); false for NOW().
+     * @param string Date occurred timestamp (YYYY-MM-DD HH:MM:SS); false for NOW().
      * @return integer New Activity ID; -1 on failure.
      */
     public function add($dataItemID, $dataItemType, $activityType,
-        $activityNotes, $enteredBy, $jobOrderID = -1, $dateCreated = false)
+        $activityNotes, $enteredBy, $jobOrderID = -1, $dateOccurred = false)
     {
         if (!ctype_digit((string) $jobOrderID) || (int) $jobOrderID <= 0)
         {
             $jobOrderID = -1;
         }
 
-        if (is_string($dateCreated) &&
-            preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $dateCreated))
+        if (is_string($dateOccurred) &&
+            preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $dateOccurred))
         {
-            $dateCreatedSQL = $this->_db->makeQueryString($dateCreated);
+            $dateOccurredSQL = $this->_db->makeQueryString($dateOccurred);
         }
         else
         {
-            $dateCreatedSQL = 'NOW()';
+            $dateOccurredSQL = 'NOW()';
         }
 
         $sql = sprintf(
@@ -112,6 +112,7 @@ class ActivityEntries
                 type,
                 notes,
                 site_id,
+                date_occurred,
                 date_created,
                 date_modified
             )
@@ -124,6 +125,7 @@ class ActivityEntries
                 %s,
                 %s,
                 %s,
+                NOW(),
                 NOW()
             )",
             $this->_db->makeQueryInteger($dataItemID),
@@ -133,7 +135,7 @@ class ActivityEntries
             $this->_db->makeQueryInteger($activityType),
             $this->_db->makeQueryString($activityNotes),
             $this->_siteID,
-            $dateCreatedSQL
+            $dateOccurredSQL
         );
 
         $queryResult = $this->_db->query($sql);
@@ -253,7 +255,7 @@ class ActivityEntries
                 "UPDATE
                     activity
                 SET
-                    date_created  = DATE_SUB(%s, INTERVAL %s HOUR),
+                    date_occurred = DATE_SUB(%s, INTERVAL %s HOUR),
                     date_modified = NOW()
                 WHERE
                     activity_id = %s

--- a/lib/ActivityEntries.php
+++ b/lib/ActivityEntries.php
@@ -430,7 +430,7 @@ class ActivityEntries
                 activity_type.short_description AS typeDescription,
                 activity.notes AS notes,
                 DATE_FORMAT(
-                    activity.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
                 ) AS dateCreated,
                 entered_by_user.first_name AS enteredByFirstName,
                 entered_by_user.last_name AS enteredByLastName,
@@ -478,12 +478,11 @@ class ActivityEntries
                 activity.joborder_id AS jobOrderID,
                 activity.notes AS notes,
                 DATE_FORMAT(
-                    activity.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
                 ) AS dateCreated,
-                activity.date_created AS dateCreatedSort,
+                activity.date_occurred AS dateCreatedSort,
                 activity.type AS type,
                 activity_type.short_description AS typeDescription,
-                activity.date_created AS dateCreatedSort,
                 entered_by_user.first_name AS enteredByFirstName,
                 entered_by_user.last_name AS enteredByLastName,
                 IF(
@@ -535,9 +534,9 @@ class ActivityEntries
                 activity.joborder_id AS jobOrderID,
                 activity.notes AS notes,
                 DATE_FORMAT(
-                    activity.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
                 ) AS dateCreated,
-                activity.date_created AS dateCreatedSort,
+                activity.date_occurred AS dateCreatedSort,
                 activity.type AS type,
                 activity_type.short_description AS typeDescription,
                 entered_by_user.first_name AS enteredByFirstName,

--- a/lib/Pipelines.php
+++ b/lib/Pipelines.php
@@ -635,7 +635,7 @@ class Pipelines
                     SELECT
                         CONCAT(
                             '<strong>',
-                            DATE_FORMAT(activity.date_created, '%%m-%%d-%%y'),
+                            DATE_FORMAT(activity.date_occurred, '%%m-%%d-%%y'),
                             ' (',
                             entered_by_user.first_name,
                             ' ',
@@ -660,7 +660,7 @@ class Pipelines
                     AND
                         activity.joborder_id = %s
                     ORDER BY
-                        activity.date_created DESC
+                        activity.date_occurred DESC
                     LIMIT 1
                 ) AS lastActivity,
                 IF((

--- a/lib/Statistics.php
+++ b/lib/Statistics.php
@@ -444,20 +444,20 @@ class Statistics
     public function getActivitiesByPeriod($period)
     {
         $criterion = $this->makePeriodCriterion(
-            'activity.date_created', $period
+            'activity.date_occurred', $period
         );
 
         $sql = sprintf(
             "SELECT
                 activity.activity_id AS activityID,
                 DATE_FORMAT(
-                    activity.date_created, '%%m'
+                    activity.date_occurred, '%%m'
                 ) AS month,
                 DATE_FORMAT(
-                    activity.date_created, '%%d'
+                    activity.date_occurred, '%%d'
                 ) AS day,
                 DATE_FORMAT(
-                    activity.date_created, '%%y'
+                    activity.date_occurred, '%%y'
                 ) AS year
             FROM
                 activity

--- a/modules/activity/dataGrids.php
+++ b/modules/activity/dataGrids.php
@@ -56,18 +56,18 @@ class ActivityDataGrid extends DataGrid
         
         if (isset($parameters['period']) && !empty($parameters['period']))
         {
-            $this->dateCriterion .= ' AND activity.date_created >= ' . $parameters['period'] . ' ';
+            $this->dateCriterion .= ' AND activity.date_occurred >= ' . $parameters['period'] . ' ';
         }
         else
         {
             if (isset($parameters['startDate']) && !empty($parameters['startDate']))
             {
-                $this->dateCriterion .= ' AND activity.date_created >= \'' .$parameters['startDate'].'\' ';
+                $this->dateCriterion .= ' AND activity.date_occurred >= \'' .$parameters['startDate'].'\' ';
             }
             
             if (isset($parameters['endDate']) && !empty($parameters['endDate']))
             {
-                $this->dateCriterion .= ' AND activity.date_created <= \''.$parameters['endDate'].'\' ';
+                $this->dateCriterion .= ' AND activity.date_occurred <= \''.$parameters['endDate'].'\' ';
             }
         }
 
@@ -96,7 +96,7 @@ class ActivityDataGrid extends DataGrid
                                       'pagerWidth'     => 110,
                                       'pagerOptional'  => true,
                                       'alphaNavigation'=> true,
-                                      'filter' => 'activity.date_created'),
+                                      'filter' => 'activity.date_occurred'),
 
             'First Name' =>     array('pagerRender'    => 'if ($rsData[\'dataItemType\']=='.DATA_ITEM_CANDIDATE.') {$ret = \'<img src="images/mru/candidate.gif" height="12" alt="" />\';} else if ($rsData[\'dataItemType\']=='.DATA_ITEM_CONTACT.') {$ret = \'<img src="images/mru/contact.gif" height="12">\';} else {$ret = \'<img src="images/mru/blank.gif">\';} if ($rsData[\'isHot\'] == 1) $className =  \'jobLinkHot\'; else $className = \'jobLinkCold\'; if ($rsData[\'dataItemType\']=='.DATA_ITEM_CANDIDATE.') {return $ret.\'&nbsp;<a href="'.CATSUtility::getIndexName().'?m=candidates&amp;a=show&amp;candidateID=\'.$rsData[\'dataItemID\'].\'" class="\'.$className.\'" title="\'.Template::escapeAttr(InfoString::make($rsData[\'dataItemType\'],$rsData[\'dataItemID\'],$rsData[\'siteID\'])).\'">\'.Template::escapeHtml($rsData[\'firstName\']).\'</a>\';} else {return  $ret.\'&nbsp;<a href="'.CATSUtility::getIndexName().'?m=contacts&amp;a=show&amp;contactID=\'.$rsData[\'dataItemID\'].\'" class="\'.$className.\'" title="\'.Template::escapeAttr(InfoString::make($rsData[\'dataItemType\'],$rsData[\'dataItemID\'],$rsData[\'siteID\'])).\'">\'.Template::escapeHtml($rsData[\'firstName\']).\'</a>\';}', 
                                      'sortableColumn'  => 'firstName',
@@ -177,9 +177,9 @@ class ActivityDataGrid extends DataGrid
                 activity.notes AS notes,
                 activity_type.short_description AS typeDescription,
                 DATE_FORMAT(
-                    activity.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
                 ) AS dateCreated,
-                activity.date_created AS dateCreatedSort,
+                activity.date_occurred AS dateCreatedSort,
                 entered_by_user.first_name AS enteredByFirstName,
                 entered_by_user.last_name AS enteredByLastName,
                 CONCAT(entered_by_user.last_name, entered_by_user.first_name) AS enteredBySort,
@@ -226,9 +226,9 @@ class ActivityDataGrid extends DataGrid
                 activity.notes AS notes,
                 activity_type.short_description AS typeDescription,
                 DATE_FORMAT(
-                    activity.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
                 ) AS dateCreated,
-                activity.date_created AS dateCreatedSort,
+                activity.date_occurred AS dateCreatedSort,
                 entered_by_user.first_name AS enteredByFirstName,
                 entered_by_user.last_name AS enteredByLastName,
                 CONCAT(entered_by_user.last_name, entered_by_user.first_name) AS enteredBySort,

--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -3151,7 +3151,7 @@ class CandidatesUI extends UserInterface
 
             $activityNote = $this->getTrimmedInput('activityNote', $_POST);
 
-            $activityDateCreated = false;
+            $activityDateOccurred = false;
             $dateFormatFlag = $_SESSION['CATS']->isDateDMY()
                 ? DATE_FORMAT_DDMMYY
                 : DATE_FORMAT_MMDDYY;
@@ -3176,7 +3176,7 @@ class CandidatesUI extends UserInterface
                         $activityHour += 12;
                     }
 
-                    $activityDateCreated = sprintf(
+                    $activityDateOccurred = sprintf(
                         '%s %02d:%02d:00',
                         DateUtility::convert(
                             '-',
@@ -3198,7 +3198,7 @@ class CandidatesUI extends UserInterface
                 $activityNote,
                 $this->_userID,
                 $regardingID,
-                $activityDateCreated
+                $activityDateOccurred
             );
             $activityTypeDescription = ResultSetUtility::getColumnValueByIDValue(
                 $activityTypes, 'typeID', $activityTypeID, 'type'

--- a/modules/contacts/ContactsUI.php
+++ b/modules/contacts/ContactsUI.php
@@ -1363,7 +1363,7 @@ class ContactsUI extends UserInterface
 
             $activityNote = $this->getTrimmedInput('activityNote', $_POST);
 
-            $activityDateCreated = false;
+            $activityDateOccurred = false;
             $dateFormatFlag = $_SESSION['CATS']->isDateDMY()
                 ? DATE_FORMAT_DDMMYY
                 : DATE_FORMAT_MMDDYY;
@@ -1388,7 +1388,7 @@ class ContactsUI extends UserInterface
                         $activityHour += 12;
                     }
 
-                    $activityDateCreated = sprintf(
+                    $activityDateOccurred = sprintf(
                         '%s %02d:%02d:00',
                         DateUtility::convert(
                             '-',
@@ -1410,7 +1410,7 @@ class ContactsUI extends UserInterface
                 $activityNote,
                 $this->_userID,
                 $regardingID,
-                $activityDateCreated
+                $activityDateOccurred
             );
             $activityTypeDescription = ResultSetUtility::getColumnValueByIDValue(
                 $activityTypes, 'typeID', $activityTypeID, 'type'

--- a/modules/home/dataGrids.php
+++ b/modules/home/dataGrids.php
@@ -223,18 +223,18 @@ class CallsDataGrid extends DataGrid
 
         if (isset($parameters['period']) && !empty($parameters['period']))
         {
-            $this->dateCriterion .= ' AND activity.date_created >= ' . $parameters['period'] . ' ';
+            $this->dateCriterion .= ' AND activity.date_occurred >= ' . $parameters['period'] . ' ';
         }
         else
         {
             if (isset($parameters['startDate']) && !empty($parameters['startDate']))
             {
-                $this->dateCriterion .= ' AND activity.date_created >= \'' .$parameters['startDate'].'\' ';
+                $this->dateCriterion .= ' AND activity.date_occurred >= \'' .$parameters['startDate'].'\' ';
             }
 
             if (isset($parameters['endDate']) && !empty($parameters['endDate']))
             {
-                $this->dateCriterion .= ' AND activity.date_created <= \''.$parameters['endDate'].'\' ';
+                $this->dateCriterion .= ' AND activity.date_occurred <= \''.$parameters['endDate'].'\' ';
             }
         }
 
@@ -300,9 +300,9 @@ class CallsDataGrid extends DataGrid
                 activity.notes AS notes,
                 activity_type.short_description AS typeDescription,
                 DATE_FORMAT(
-                    activity.date_created, '%%m-%%d-%%y %%h:%%i %%p'
+                    activity.date_occurred, '%%m-%%d-%%y %%h:%%i %%p'
                 ) AS dateCreated,
-                activity.date_created AS dateCreatedSort,
+                activity.date_occurred AS dateCreatedSort,
                 entered_by_user.first_name AS enteredByFirstName,
                 entered_by_user.last_name AS enteredByLastName,
                 CONCAT(entered_by_user.last_name, entered_by_user.first_name) AS enteredBySort,
@@ -354,9 +354,9 @@ class CallsDataGrid extends DataGrid
                 activity.notes AS notes,
                 activity_type.short_description AS typeDescription,
                 DATE_FORMAT(
-                    activity.date_created, '%%m-%%d-%%y %%h:%%i %%p'
+                    activity.date_occurred, '%%m-%%d-%%y %%h:%%i %%p'
                 ) AS dateCreated,
-                activity.date_created AS dateCreatedSort,
+                activity.date_occurred AS dateCreatedSort,
                 entered_by_user.first_name AS enteredByFirstName,
                 entered_by_user.last_name AS enteredByLastName,
                 CONCAT(entered_by_user.last_name, entered_by_user.first_name) AS enteredBySort,

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1517,6 +1517,16 @@ class CATSSchema
                     `ce`.`joborder_id` IS NOT NULL AND
                     `jo`.`joborder_id` IS NULL;
             ',
+            '380' => '
+                ALTER TABLE `activity`
+                ADD COLUMN `date_occurred` datetime NOT NULL DEFAULT \'1000-01-01 00:00:00\'
+                BEFORE `date_created`;
+                UPDATE `activity`
+                SET `date_occurred` = `date_created`;
+                CREATE INDEX `IDX_date_occurred` ON `activity` (`date_occurred`);
+                CREATE INDEX `IDX_site_occurred` ON `activity` (`site_id`,`date_occurred`);
+                CREATE INDEX `IDX_activity_site_type_occurred_job` ON `activity` (`site_id`,`data_item_type`,`date_occurred`,`entered_by`,`joborder_id`);
+            ',
 
         );
     }

--- a/test/features/bootstrap/FeatureContext.php
+++ b/test/features/bootstrap/FeatureContext.php
@@ -88,6 +88,19 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
             }
         });
     }
+
+    /**
+     * @Then I wait until I see :text
+     */
+    public function iWaitUntilISee($text)
+    {
+        $this->spins(function() use ($text) {
+            $pageText = $this->getSession()->getPage()->getText();
+            if (strpos($pageText, $text) === false) {
+                throw new Exception(sprintf('Could not see text "%s" yet.', $text));
+            }
+        });
+    }
     
     /**
      * @Then /^I wait for the activity note box to appear$/

--- a/test/features/job-orders.feature
+++ b/test/features/job-orders.feature
@@ -340,5 +340,5 @@ Feature: Job Orders
     And press "Add Candidate"
     And press "Close"
     And I switch to the iframe ""
-    Then I should see "John"
+    Then I wait until I see "John"
     And I should see "Doe"


### PR DESCRIPTION
This PR separates the functional occurrence timestamp of activity records from their technical creation timestamp.

PR #758 made it possible to log activities with a manual date and time, but the manually selected activity timestamp was stored in `activity.date_created`. That made the activity timeline behave as intended, but it also changed the meaning of `date_created`: instead of always representing when the database row was created, it could represent when the activity occurred.

This PR adds a dedicated `activity.date_occurred` column and backfills it from the existing `date_created` values so that existing activity timelines keep their current ordering and displayed timestamps after migration.

Manual activity dates are now stored in `date_occurred`, while `date_created` is always set to `NOW()` when a new activity row is inserted. Editing an activity date also updates `date_occurred` instead of overwriting `date_created`.

Activity timelines, activity grids, date filters, activity statistics, and latest-activity lookups now use `date_occurred` as the functional activity timestamp. Existing output aliases such as `dateCreated`, `dateCreatedSort` and `lastActivity` are intentionally kept unchanged to avoid unnecessary template and JavaScript changes.

This restores `date_created` as the technical record creation timestamp while preserving the user-facing behavior introduced by manual activity dates.