### PR TITLE
security: deny Apache web access to temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docker/persist/*
 vendor/*
 attachments/*
 temp/*
+!temp/.htaccess
 uploads/*
 # Ignore Mac DS_Store files
 .DS_Store

--- a/temp/.htaccess
+++ b/temp/.htaccess
@@ -1,0 +1,10 @@
+Options -ExecCGI -Indexes
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>


### PR DESCRIPTION
Deny direct HTTP access to the temp directory for Apache deployments by adding a dedicated .htaccess file.

The root .htaccess disables directory indexes and sets security headers, but it does not prevent direct access to known files below temp/. This change mirrors the existing deny-by-default approach used for attachments/ and helps prevent temporary files from being served directly by Apache when AllowOverride is enabled.

The temp/empty placeholder is removed because the new versioned temp/.htaccess file now keeps the temp directory present in the repository. The .gitignore rules are updated so temporary files remain ignored while temp/.htaccess stays tracked.