### PR TITLE
fix: correct job order repository exception namespace

### DIFF
--- a/src/OpenCATS/Entity/JobOrderRepositoryException.php
+++ b/src/OpenCATS/Entity/JobOrderRepositoryException.php
@@ -1,3 +1,4 @@
 <?php
-namespace \OpenCATS\Entity;
-class JobOrderRepositoryException extends Exception {}
+namespace OpenCATS\Entity;
+
+class JobOrderRepositoryException extends \Exception {}


### PR DESCRIPTION
This PR fixes the namespace declaration in `JobOrderRepositoryException`.

The file previously declared the namespace with a leading backslash, which causes a PHP parse error when the file is linted or loaded. The change removes the invalid leading backslash and makes the base exception reference explicit by extending `\Exception`.