### PR TITLE
fix: prevent database column parameter deprecation

### DIFF
--- a/lib/DatabaseConnection.php
+++ b/lib/DatabaseConnection.php
@@ -259,7 +259,7 @@ class DatabaseConnection
      * @param integer Column number.
      * @return array Multi-dimensional associative result set array, or array()
      */
-    public function getColumn($query = null, $row, $column)
+    public function getColumn($query, $row, $column)
     {
         if ($query != null)
         {


### PR DESCRIPTION
This PR updates the `DatabaseConnection::getColumn()` method signature to avoid a PHP deprecation caused by an optional parameter being declared before required parameters.

The previous signature declared `$query` with a default value even though `$row` and `$column` were required. Modern PHP versions implicitly treat this as required and emit a deprecation warning when the file is loaded.

The change removes the unnecessary default value from `$query`. Existing call sites already pass all three arguments, so no call-site changes are required and the existing behavior is preserved.

Validation was performed by linting `lib/DatabaseConnection.php` and loading the file with `E_ALL` enabled to confirm that the `DatabaseConnection::getColumn()` parameter-order deprecation is no longer emitted.