### PR TITLE
fix: prevent activity update parameter deprecations

### DIFF
--- a/lib/ActivityEntries.php
+++ b/lib/ActivityEntries.php
@@ -181,7 +181,7 @@ class ActivityEntries
      * @return boolean True if successful; false otherwise.
      */
     public function update($activityID, $activityType, $activityNotes,
-        $jobOrderID = false, $date = false, $timezoneOffset)
+        $jobOrderID, $date, $timezoneOffset)
     {
         /* Get some extra information about the activity entry that we'll
          * need later on.


### PR DESCRIPTION
This PR fixes PHP deprecations in `ActivityEntries::update()` caused by optional parameters being declared before a required parameter.

The existing OpenCATS call site already passes all six arguments to the method, including the job order ID, date and timezone offset. Because of that, the default values on `$jobOrderID` and `$date` are not needed for current callers. Removing those defaults keeps the existing parameter order and behavior intact while avoiding the parameter-order deprecations on modern PHP versions.

Validation was performed by linting `lib/ActivityEntries.php`, checking the existing call site and loading the file with `E_ALL` enabled to confirm the `ActivityEntries::update()` parameter-order deprecations no longer appear.