### PR TITLE
fix: avoid deprecated E_STRICT usage

### DIFF
--- a/lib/Mailer.php
+++ b/lib/Mailer.php
@@ -50,9 +50,6 @@ define('MAILER_MODE_PHP',      1);
 define('MAILER_MODE_SENDMAIL', 2);
 define('MAILER_MODE_SMTP',     3);
 
-$errorReporting = error_reporting();
-error_reporting($errorReporting & ~ E_STRICT);
-
 /**
  *	E-Mail Abstraction Layer
  *	@package    CATS


### PR DESCRIPTION
This PR removes the deprecated `E_STRICT` error reporting mask from `lib/Mailer.php`.

Modern PHP versions deprecate the `E_STRICT` constant itself, so referencing it can emit a deprecation while loading the mailer code. The previous suppression was only intended for older strict standards notices and is no longer needed for current PHP versions.

Validation was performed by linting `lib/Mailer.php` and loading the file with `E_ALL` enabled to confirm that the `E_STRICT` deprecation no longer appears.