### PR TITLE
feat: detect and gate pending install migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
           [ -n "$integrationtestdb_container" ] || { echo "integrationtestdb container ID not found"; exit 1; }
           timeout 180s bash -c "until [ \"\$(docker inspect --format '{{.State.Health.Status}}' \"${integrationtestdb_container}\" 2>/dev/null)\" = \"healthy\" ]; do sleep 3; done"
 
+          docker compose -f docker-compose-test.yml exec -T --workdir /var/www/public php php test/scripts/finalizeInstallSchemaVersion.php
+
           # 2. Pre-clean the integration database
           docker compose -f docker-compose-test.yml exec -T integrationtestdb mysql -udev -pdev -e "DROP DATABASE IF EXISTS cats_integrationtest; CREATE DATABASE cats_integrationtest;"
 

--- a/ajax.php
+++ b/ajax.php
@@ -41,6 +41,7 @@ include_once(LEGACY_ROOT . '/lib/DatabaseConnection.php');
 include_once(LEGACY_ROOT . '/lib/Session.php'); /* Depends: MRU, Users, DatabaseConnection. */
 include_once(LEGACY_ROOT . '/lib/AJAXInterface.php');
 include_once(LEGACY_ROOT . '/lib/CATSUtility.php');
+include_once(LEGACY_ROOT . '/lib/SchemaMigrationStatus.php');
 
 
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
@@ -117,6 +118,8 @@ if ($installerActive)
     }
 }
 
+$module = '';
+
 if (strpos($_REQUEST['f'], ':') === false)
 {
     $function = preg_replace("/[^A-Za-z0-9]/", "", $_REQUEST['f']);
@@ -132,6 +135,30 @@ else
     $function = preg_replace("/[^A-Za-z0-9]/", "", $parameters[1]);
     
     $filename = sprintf('modules/%s/ajax/%s.php', $module, $function);
+}
+
+/* Fresh installer AJAX remains available. On installed systems, only the
+ * existing maintenance action may pass the pending-migration AJAX gate.
+ */
+$maintenanceAJAXAllowed =
+    $installerActive ||
+    ($module === 'install' && $function === 'maint');
+
+if (isset($_SESSION['CATS']) &&
+    $_SESSION['CATS']->isLoggedIn() &&
+    !$maintenanceAJAXAllowed &&
+    SchemaMigrationStatus::hasPendingInstallMigrations())
+{
+    header('Content-type: text/xml; charset=' . AJAX_ENCODING);
+    echo '<?xml version="1.0" encoding="', AJAX_ENCODING, '"?>', "\n";
+    echo(
+        "<data>\n" .
+        "    <errorcode>-1</errorcode>\n" .
+        "    <errormessage>Database maintenance is required.</errormessage>\n" .
+        "</data>\n"
+    );
+
+    die();
 }
 
 if (!is_readable($filename))

--- a/index.php
+++ b/index.php
@@ -68,6 +68,7 @@ include_once(LEGACY_ROOT . '/lib/Session.php'); /* Depends: MRU, Users, Database
 include_once(LEGACY_ROOT . '/lib/UserInterface.php'); /* Depends: Template, Session. */
 include_once(LEGACY_ROOT . '/lib/ModuleUtility.php'); /* Depends: UserInterface */
 include_once(LEGACY_ROOT . '/lib/TemplateUtility.php'); /* Depends: ModuleUtility, Hooks */
+include_once(LEGACY_ROOT . '/lib/SchemaMigrationStatus.php');
 
 
 /* Give the session a unique name to avoid conflicts and start the session. */
@@ -153,10 +154,44 @@ if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST' &
     }
 }
 
+$isPublicRequest =
+    (isset($careerPage) && $careerPage) ||
+    (isset($_GET['showCareerPortal']) && $_GET['showCareerPortal'] == '1') ||
+    (isset($rssPage) && $rssPage) ||
+    (isset($xmlPage) && $xmlPage);
+$isMigrationGateExcluded =
+    (isset($_GET['m']) && ($_GET['m'] === 'login' || $_GET['m'] === 'logout'));
+
+if ($_SESSION['CATS']->isLoggedIn() &&
+    !$isPublicRequest &&
+    !$isMigrationGateExcluded &&
+    SchemaMigrationStatus::hasPendingInstallMigrations())
+{
+    $template = new Template();
+    $template->assign(
+        'isAdministrator',
+        $_SESSION['CATS']->getAccessLevel(ACL::SECOBJ_ROOT) >= ACCESS_LEVEL_SA
+    );
+    $template->display('./modules/login/PendingMigrations.tpl');
+    die();
+}
+
 /* Check to see if we are supposed to display the career page. */
 if (((isset($careerPage) && $careerPage) ||
     (isset($_GET['showCareerPortal']) && $_GET['showCareerPortal'] == '1')))
 {
+    if (SchemaMigrationStatus::hasPendingInstallMigrations())
+    {
+        header('HTTP/1.1 503 Service Unavailable');
+        header('Content-Type: text/html; charset=UTF-8');
+
+        echo '<!DOCTYPE html>',
+             '<html><head><title>Career Portal Maintenance</title></head><body>',
+             '<p>The career portal is temporarily unavailable while system maintenance is in progress. Please try again later.</p>',
+             '</body></html>';
+        die();
+    }
+
     ModuleUtility::loadModule('careers');
 }
 

--- a/lib/SchemaMigrationStatus.php
+++ b/lib/SchemaMigrationStatus.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * CATS
+ * Schema Migration Status Library
+ *
+ * @package    CATS
+ * @subpackage Library
+ */
+
+include_once(LEGACY_ROOT . '/modules/install/Schema.php');
+
+class SchemaMigrationStatus
+{
+    private static $_latestInstallSchemaVersion = NULL;
+    private static $_storedInstallSchemaVersion = NULL;
+    private static $_storedInstallSchemaVersionLoaded = false;
+    private static $_hasPendingInstallMigrations = NULL;
+
+    /* Prevent this class from being instantiated. */
+    private function __construct() {}
+    private function __clone() {}
+
+    /**
+     * Returns the latest install schema version available in the code.
+     *
+     * @return integer
+     */
+    public static function getLatestInstallSchemaVersion()
+    {
+        if (self::$_latestInstallSchemaVersion !== NULL)
+        {
+            return self::$_latestInstallSchemaVersion;
+        }
+
+        $schemaVersions = array_keys(CATSSchema::get());
+        self::$_latestInstallSchemaVersion = empty($schemaVersions) ? 0 : (int) max($schemaVersions);
+
+        return self::$_latestInstallSchemaVersion;
+    }
+
+    /**
+     * Returns the install schema version stored in the database.
+     *
+     * NULL or an empty string is not a known applied schema version. It must
+     * remain unresolved until an explicit installer or maintenance flow
+     * finalizes it; this read-only checker must not normalize it.
+     *
+     * @return mixed Integer version, NULL or empty string if unresolved,
+     *               or false if the row does not exist.
+     */
+    public static function getStoredInstallSchemaVersion()
+    {
+        if (self::$_storedInstallSchemaVersionLoaded)
+        {
+            return self::$_storedInstallSchemaVersion;
+        }
+
+        $db = DatabaseConnection::getInstance();
+
+        $sql = sprintf(
+            "SELECT
+                version AS version
+            FROM
+                module_schema
+            WHERE
+                name = %s",
+            $db->makeQueryString('install')
+        );
+        $rs = $db->getAssoc($sql);
+
+        if (empty($rs))
+        {
+            self::$_storedInstallSchemaVersion = false;
+        }
+        else
+        {
+            self::$_storedInstallSchemaVersion = $rs['version'];
+        }
+
+        self::$_storedInstallSchemaVersionLoaded = true;
+
+        return self::$_storedInstallSchemaVersion;
+    }
+
+    /**
+     * Returns whether install schema migrations are pending.
+     *
+     * @return boolean
+     */
+    public static function hasPendingInstallMigrations()
+    {
+        if (self::$_hasPendingInstallMigrations !== NULL)
+        {
+            return self::$_hasPendingInstallMigrations;
+        }
+
+        $storedVersion = self::getStoredInstallSchemaVersion();
+
+        if ($storedVersion === false ||
+            $storedVersion === NULL ||
+            $storedVersion === '')
+        {
+            /* Unknown versions require explicit install or maintenance finalization. */
+            self::$_hasPendingInstallMigrations = true;
+            return true;
+        }
+
+        self::$_hasPendingInstallMigrations =
+            (int) $storedVersion < self::getLatestInstallSchemaVersion();
+
+        return self::$_hasPendingInstallMigrations;
+    }
+
+    /**
+     * Clears cached migration status after explicit maintenance updates.
+     *
+     * @return void
+     */
+    public static function clearCache()
+    {
+        self::$_latestInstallSchemaVersion = NULL;
+        self::$_storedInstallSchemaVersion = NULL;
+        self::$_storedInstallSchemaVersionLoaded = false;
+        self::$_hasPendingInstallMigrations = NULL;
+    }
+}
+
+?>

--- a/modules/login/PendingMigrations.tpl
+++ b/modules/login/PendingMigrations.tpl
@@ -1,0 +1,41 @@
+<?php /* Pending install schema migration notice. */ ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+    <head>
+        <title>OpenCATS - Maintenance Required</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=<?php echo(HTML_ENCODING); ?>" />
+        <style type="text/css" media="all">@import "<?php echo TemplateUtility::getVersionedAssetURL('modules/install/install.css'); ?>";</style>
+    </head>
+
+    <body>
+        <div id="headerBlock">
+            <span id="mainLogo">OpenCATS</span><br />
+            <span id="subMainLogo">Applicant Tracking System</span>
+        </div>
+
+        <div id="contents">
+            <div id="login" style="width: 500px;">
+                <div style="text-align: left;">
+                    <span style="font-weight: bold;">Maintenance Required</span>
+
+                    <?php if ($this->isAdministrator): ?>
+                        <p>Database migrations are pending. OpenCATS should be updated before normal use continues.</p>
+                        <p>Open the <a href="installwizard.php">Installation Wizard</a> to complete the upgrade.</p>
+                    <?php else: ?>
+                        <p>Database maintenance is required before OpenCATS can be used normally. Please contact your administrator.</p>
+                    <?php endif; ?>
+                </div>
+
+                <div style="clear: both;"></div>
+            </div>
+
+            <div style="clear: both;"></div>
+            <br />
+
+            <div id="footerBlock">
+                <span class="footerCopyright"><?php echo(COPYRIGHT_HTML); ?></span>
+            </div>
+        </div>
+    </body>
+</html>

--- a/test/runAllTests.sh
+++ b/test/runAllTests.sh
@@ -2,6 +2,7 @@
 cd /var/www/public/
 dockerize -wait tcp://opencats_test_mariadb:3306 -wait http://opencats_test_web:80 -timeout 30s
 php test/scripts/waitForDb.php
+php test/scripts/finalizeInstallSchemaVersion.php
 cat config.php
 ./vendor/bin/phpunit --testsuite IntegrationTests
 ./vendor/bin/behat -v -c ./test/behat.yml --suite="default"

--- a/test/scripts/finalizeInstallSchemaVersion.php
+++ b/test/scripts/finalizeInstallSchemaVersion.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Finalize the bundled snapshot schema for integration tests without
+ * hard-coding the current install schema version.
+ */
+
+include_once('./config.php');
+include_once(LEGACY_ROOT . '/constants.php');
+include_once(LEGACY_ROOT . '/lib/DatabaseConnection.php');
+include_once(LEGACY_ROOT . '/lib/SchemaMigrationStatus.php');
+
+$latestVersion = SchemaMigrationStatus::getLatestInstallSchemaVersion();
+if ($latestVersion <= 0)
+{
+    throw new RuntimeException('Unable to determine the latest install schema version.');
+}
+
+$db = DatabaseConnection::getInstance();
+$result = $db->query(sprintf(
+    "UPDATE
+        module_schema
+    SET
+        version = %d
+    WHERE
+        name = %s",
+    $latestVersion,
+    $db->makeQueryString('install')
+));
+
+if ($result === false)
+{
+    throw new RuntimeException('Unable to finalize the install schema version.');
+}
+
+SchemaMigrationStatus::clearCache();
+if ((int) SchemaMigrationStatus::getStoredInstallSchemaVersion() !== $latestVersion)
+{
+    throw new RuntimeException('The install schema version was not finalized.');
+}
+
+?>


### PR DESCRIPTION
## Summary

This PR adds automatic detection for pending install schema migrations and prevents OpenCATS from continuing normal operation while those migrations still need to be finalized.

It introduces a central, read-only migration status check for the install schema (`lib/SchemaMigrationStatus.php`). While install migrations are pending, it shows authenticated users a **Maintenance Required** notice instead of the normal UI, blocks application AJAX requests, and returns a maintenance message for the public Careers Portal.

Site administrators are pointed to the existing Installation Wizard (`installwizard.php`) to complete the upgrade, while recruiters and other non-admin users are shown a message telling them to contact their administrator.

The integration test setup finalizes the install schema version dynamically from `modules/install/Schema.php`, so CI test databases represent an already finalized installed snapshot without hard-coding the current install schema version in `db/cats_schema.sql`.

## Motivation

Previously, pending install schema migrations could be difficult to notice during normal application usage. This could allow users to continue using OpenCATS while the database schema was not fully aligned with the application code and the Careers Portal could remain publicly available during that state.

Detecting pending migrations centrally makes this state explicit and safer. Blocking the Careers Portal avoids exposing applicants to an application that still requires maintenance, while gating authenticated application requests prevents existing sessions or direct module URLs from bypassing the warning.

Linking administrators to the existing Installation Wizard keeps migration execution on the current, well-tested path and avoids introducing a second migration-execution path in this PR. Automating the migration itself is deliberately left to a separate follow-up PR so this change stays focused on detection and gating.