### PR TITLE
fix: correct migration 377 regex escaping

### DIFF
--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1476,8 +1476,8 @@ class CATSSchema
                         $notes = $row[\'notes\'];
 
                         $cleanedNotes = preg_replace(
-                            "/<span\\b(?=[^>]*\\bstyle\\s*=\\s*([\\\"\\\'])[^\\\"\\\']*\\bcolor\\s*:\\s*#ff6c00\\b[^\\\"\\\']*\\1)[^>]*>(.*?)<\\/span>/is",
-                            "$2",
+                            \'/<span\\b(?=[^>]*\\bstyle\\s*=\\s*([\\\'"])[^\\\'"]*\\bcolor\\s*:\\s*#ff6c00\\b[^\\\'"]*\\1)[^>]*>(.*?)<\\/span>/is\',
+                            \'$2\',
                             $notes
                         );
 


### PR DESCRIPTION
This PR fixes the escaping of the regular expression used in migration 377.

The affected code is stored as a PHP string and evaluated later, so the regex needs to be escaped for both the surrounding migration string and the evaluated PHP code. The previous escaping caused the evaluated regex to differ from the intended pattern.

The updated version preserves the intended match behavior while making the evaluated regex valid and reliable. It also keeps the replacement string quoted correctly so `$2` is treated as the regex capture group replacement instead of a PHP variable.