### PR TITLE
chore: add IANA timezone column to site schema

### DIFF
--- a/db/cats_schema.sql
+++ b/db/cats_schema.sql
@@ -992,6 +992,7 @@ CREATE TABLE `site` (
   `account_deleted` int(1) NOT NULL DEFAULT '0',
   `reason_disabled` text CHARACTER SET utf8,
   `time_zone` int(5) DEFAULT '0',
+  `time_zone_iana` varchar(64) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'UTC',
   `time_format_24` int(1) DEFAULT '0',
   `date_format_ddmmyy` int(1) DEFAULT '0',
   `default_phone_country_code` varchar(8) COLLATE utf8_unicode_ci NOT NULL DEFAULT '+1',
@@ -1010,8 +1011,8 @@ CREATE TABLE `site` (
 
 /*Data for the table `site` */
 
-insert  into `site`(`site_id`,`name`,`is_demo`,`user_licenses`,`entered_by`,`date_created`,`unix_name`,`company_id`,`is_free`,`account_active`,`account_deleted`,`reason_disabled`,`time_zone`,`time_format_24`,`date_format_ddmmyy`,`is_hr_mode`,`file_size_kb`,`page_views`,`page_view_days`,`last_viewed_day`,`first_time_setup`,`localization_configured`,`agreed_to_license`,`limit_warning`) values (1,'example.com',0,0,0,'1000-01-01 00:00:00',NULL,NULL,0,1,0,NULL,2,0,1,0,0,574,1,'1000-01-01',0,0,1,0);
-insert  into `site`(`site_id`,`name`,`is_demo`,`user_licenses`,`entered_by`,`date_created`,`unix_name`,`company_id`,`is_free`,`account_active`,`account_deleted`,`reason_disabled`,`time_zone`,`time_format_24`,`date_format_ddmmyy`,`is_hr_mode`,`file_size_kb`,`page_views`,`page_view_days`,`last_viewed_day`,`first_time_setup`,`localization_configured`,`agreed_to_license`,`limit_warning`) values (180,'CATS_ADMIN',0,0,0,'1000-01-01 00:00:00','catsadmin',NULL,0,1,0,NULL,2,0,1,0,0,0,0,'1000-01-01',0,0,0,0);
+insert  into `site`(`site_id`,`name`,`is_demo`,`user_licenses`,`entered_by`,`date_created`,`unix_name`,`company_id`,`is_free`,`account_active`,`account_deleted`,`reason_disabled`,`time_zone`,`time_zone_iana`,`time_format_24`,`date_format_ddmmyy`,`is_hr_mode`,`file_size_kb`,`page_views`,`page_view_days`,`last_viewed_day`,`first_time_setup`,`localization_configured`,`agreed_to_license`,`limit_warning`) values (1,'example.com',0,0,0,'1000-01-01 00:00:00',NULL,NULL,0,1,0,NULL,2,'UTC',0,1,0,0,574,1,'1000-01-01',0,0,1,0);
+insert  into `site`(`site_id`,`name`,`is_demo`,`user_licenses`,`entered_by`,`date_created`,`unix_name`,`company_id`,`is_free`,`account_active`,`account_deleted`,`reason_disabled`,`time_zone`,`time_zone_iana`,`time_format_24`,`date_format_ddmmyy`,`is_hr_mode`,`file_size_kb`,`page_views`,`page_view_days`,`last_viewed_day`,`first_time_setup`,`localization_configured`,`agreed_to_license`,`limit_warning`) values (180,'CATS_ADMIN',0,0,0,'1000-01-01 00:00:00','catsadmin',NULL,0,1,0,NULL,2,'UTC',0,1,0,0,0,0,'1000-01-01',0,0,0,0);
 
 /*Table structure for table `sph_counter` */
 

--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1527,6 +1527,11 @@ class CATSSchema
                 CREATE INDEX `IDX_site_occurred` ON `activity` (`site_id`,`date_occurred`);
                 CREATE INDEX `IDX_activity_site_type_occurred_job` ON `activity` (`site_id`,`data_item_type`,`date_occurred`,`entered_by`,`joborder_id`);
             ',
+            '381' => 'PHP:
+                $db->query("ALTER IGNORE TABLE `site`
+                    ADD COLUMN `time_zone_iana` varchar(64) NOT NULL DEFAULT \'UTC\'
+                    AFTER `time_zone`", true);
+            ',
 
         );
     }


### PR DESCRIPTION
## Summary

This PR adds a new `time_zone_iana` column to the `site` table.

Fresh installations now create the column as part of the base schema and existing installations receive it through schema update. The column defaults to `UTC`.

This PR intentionally does not change the existing legacy `site.time_zone` column, installer behavior, runtime timezone handling, timestamp storage or timestamp display behavior.

## Motivation

OpenCATS currently relies on a legacy numeric timezone offset. This is not sufficient for future timezone-aware timestamp handling, especially if timestamp storage is later migrated toward UTC and display logic needs to use real regional timezone rules.

Before the installer or settings screens can start writing an IANA timezone identifier, the database schema must provide a place to store it. This is especially important for upgraded installations: the installer may run before later schema migrations or setup changes can depend on the new field. Without adding the column first, future installer or upgrade logic would not be able to reliably persist the selected IANA timezone for both fresh and existing instances.

This PR is therefore a small preparatory schema change. It makes `site.time_zone_iana` available while keeping all existing offset-based behavior unchanged. The actual transition to writing IANA timezone values, changing runtime timezone handling, migrating timestamps to UTC, ..., are intentionally left for follow-up PRs.