### PR TITLE
fix: correct column position syntax in migration 380

### DIFF
--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1520,7 +1520,7 @@ class CATSSchema
             '380' => '
                 ALTER TABLE `activity`
                 ADD COLUMN `date_occurred` datetime NOT NULL DEFAULT \'1000-01-01 00:00:00\'
-                BEFORE `date_created`;
+                AFTER `entered_by`;
                 UPDATE `activity`
                 SET `date_occurred` = `date_created`;
                 CREATE INDEX `IDX_date_occurred` ON `activity` (`date_occurred`);


### PR DESCRIPTION
This fixes the SQL syntax used in migration 380 when adding the `date_occurred` column to the `activity` table.

The migration previously used `BEFORE date_created`, which is not valid syntax for `ALTER TABLE ... ADD COLUMN` in MySQL/MariaDB. This could cause the migration to fail when upgrading an existing installation.

The column is now added `AFTER entered_by`, which is valid MySQL/MariaDB syntax and preserves the intended column order because `entered_by` is directly before `date_created` in the current schema.

This keeps the migration aligned with the schema used for fresh installations.