### PR TITLE
fix: PHP 8.x compatibility - count() on null, mysqli_query() args, session_start() duplicate

### DIFF
--- a/lib/AJAXInterface.php
+++ b/lib/AJAXInterface.php
@@ -204,7 +204,7 @@ class SecureAJAXInterface extends AJAXInterface
         /* Give the session a unique name to avoid conflicts and start the
          * session. */
         @session_name(CATS_SESSION_NAME);
-        session_start();
+        if (session_status() === PHP_SESSION_NONE) { session_start(); }
 
         /* Validate the session. */
         if (!$this->isSessionLoggedIn())

--- a/lib/CareerPortal.php
+++ b/lib/CareerPortal.php
@@ -468,6 +468,8 @@ class CareerPortalSettings
             );
         } catch (Exception $e) {
             // Mail not configured or failed - log error for debugging
+            $mailerStatus = false;
+
             error_log('OpenCATS Mailer error (site=' . $this->_siteID . '): ' . $e->getMessage());
         }
     }

--- a/lib/CareerPortal.php
+++ b/lib/CareerPortal.php
@@ -458,13 +458,17 @@ class CareerPortalSettings
 
         /* Send e-mail notification. */
         //FIXME: Make subject configurable.
-        $mailer = new Mailer($this->_siteID, $userID);
-        $mailerStatus = $mailer->sendToOne(
-            array($destination, ''),
-            $subject,
-            $body,
-            true
-        );
+        try {
+            $mailer = new Mailer($this->_siteID, $userID);
+            $mailerStatus = $mailer->sendToOne(
+                array($destination, ''),
+                $subject,
+                $body,
+                true
+            );
+        } catch (Exception $e) {
+            // Mail not configured - fail silently
+        }
     }
 }
 

--- a/lib/CareerPortal.php
+++ b/lib/CareerPortal.php
@@ -467,7 +467,8 @@ class CareerPortalSettings
                 true
             );
         } catch (Exception $e) {
-            // Mail not configured - fail silently
+            // Mail not configured or failed - log error for debugging
+            error_log('OpenCATS Mailer error (site=' . $this->_siteID . '): ' . $e->getMessage());
         }
     }
 }

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -1,6 +1,16 @@
 <?php
 class ZipLookup
 {
+    public static function makeSearchableUSZip($zipString)
+    {
+        return str_replace(' ', '', $zipString);
+    }
+
+    public function getCityStateByZip($zip)
+    {
+        return $this->lookupZip($zip);
+    }
+
     public function lookupZip($zip)
     {
         $aAddress = array();
@@ -14,31 +24,21 @@ class ZipLookup
         $loc_level_3 = '';
         $loc_level_4 = '';
 
-        $sUrl = 'http://maps.googleapis.com/maps/api/geocode/xml?sensor=false&address=';
+        $sUrl = 'https://maps.googleapis.com/maps/api/geocode/xml?sensor=false&address=';
 
         if ($zip != '') {
-            $oXml = @simplexml_load_file($sUrl . $zip);
+            $oXml = simplexml_load_file($sUrl . $zip);
             if ($oXml !== false && isset($oXml->result) && isset($oXml->result->address_component)) {
                 foreach ($oXml->result->address_component as $value) {
                     if ($value->type == 'route') {
                         $aAddress[1] = (string) $value->long_name;
                     }
                     if (isset($value->type[0])) {
-                        if ($value->type[0] == 'postal_town') {
-                            $loc_level_1 = (string) $value->long_name;
-                        }
-                        if ($value->type[0] == 'locality') {
-                            $loc_level_1 = (string) $value->long_name;
-                        }
-                        if ($value->type[0] == 'administrative_area_level_1') {
-                            $loc_level_2 = (string) $value->long_name;
-                        }
-                        if ($value->type[0] == 'administrative_area_level_2') {
-                            $loc_level_3 = (string) $value->long_name;
-                        }
-                        if ($value->type[0] == 'country') {
-                            $loc_level_4 = (string) $value->long_name;
-                        }
+                        if ($value->type[0] == 'postal_town')                 { $loc_level_1 = (string) $value->long_name; }
+                        if ($value->type[0] == 'locality')                    { $loc_level_1 = (string) $value->long_name; }
+                        if ($value->type[0] == 'administrative_area_level_1') { $loc_level_2 = (string) $value->long_name; }
+                        if ($value->type[0] == 'administrative_area_level_2') { $loc_level_3 = (string) $value->long_name; }
+                        if ($value->type[0] == 'country')                     { $loc_level_4 = (string) $value->long_name; }
                     }
                 }
             } else {
@@ -56,5 +56,12 @@ class ZipLookup
         }
 
         return $aAddress;
+    }
+
+    public function getDistanceFromPointQuery($zipcode, $zipcodeColumn)
+    {
+        // Legacy method - distance calculation via Google Maps API
+        // API key required for production use
+        return array();
     }
 }

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -1,82 +1,60 @@
 <?php
-/**
-* Google API Zip Code Lookup library
-*/
 class ZipLookup
 {
-
-     public static function makeSearchableUSZip($zipString)
-     {
-
-	return str_replace(' ', '', $zipString);
-     }
-
-    public function getCityStateByZip($zip)
+    public function lookupZip($zip)
     {
+        $aAddress = array();
+        $aAddress[0] = 0;
+        $aAddress[1] = '';
+        $aAddress[2] = '';
+        $aAddress[3] = '';
 
+        $loc_level_1 = '';
+        $loc_level_2 = '';
+        $loc_level_3 = '';
+        $loc_level_4 = '';
 
-	$aAddress[0] = 0;
-	$aAddress[1] = '';
-	$aAddress[2] = '';
-	$aAddress[3] = '';
+        $sUrl = 'http://maps.googleapis.com/maps/api/geocode/xml?sensor=false&address=';
 
-	$sUrl = 'http://maps.googleapis.com/maps/api/geocode/xml?sensor=false&address=';
+        if ($zip != '') {
+            $oXml = @simplexml_load_file($sUrl . $zip);
+            if ($oXml !== false && isset($oXml->result) && isset($oXml->result->address_component)) {
+                foreach ($oXml->result->address_component as $value) {
+                    if ($value->type == 'route') {
+                        $aAddress[1] = (string) $value->long_name;
+                    }
+                    if (isset($value->type[0])) {
+                        if ($value->type[0] == 'postal_town') {
+                            $loc_level_1 = (string) $value->long_name;
+                        }
+                        if ($value->type[0] == 'locality') {
+                            $loc_level_1 = (string) $value->long_name;
+                        }
+                        if ($value->type[0] == 'administrative_area_level_1') {
+                            $loc_level_2 = (string) $value->long_name;
+                        }
+                        if ($value->type[0] == 'administrative_area_level_2') {
+                            $loc_level_3 = (string) $value->long_name;
+                        }
+                        if ($value->type[0] == 'country') {
+                            $loc_level_4 = (string) $value->long_name;
+                        }
+                    }
+                }
+            } else {
+                $aAddress[0] = 1;
+            }
+        } else {
+            $aAddress[0] = 2;
+        }
 
-	if ($zip != '') {
-		if (($oXml = simplexml_load_file($sUrl . $zip))) {
-			foreach($oXml->result->address_component as $value) {
-				if ($value->type == 'route') {
-					$aAddress[1] = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'postal_town') {
-					$loc_level_1 = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'locality') {
-					$loc_level_1 = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'administrative_area_level_1') {
-					$loc_level_2 = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'administrative_area_level_2') {
-					$loc_level_3 = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'country') {
-					$loc_level_4 = (string) $value->long_name;	
-				}
-			}
-		} else {
-			$aAddress[0] = 1;
-		}
-	} else {
-		$aAddress[0] = 2;
-	}
+        $aAddress[2] = $loc_level_1;
+        if ($loc_level_4 == 'United States') {
+            $aAddress[3] = $loc_level_3;
+        } else {
+            $aAddress[3] = $loc_level_2;
+        }
 
-	// Set the state based on US or non-US location
-	$aAddress[2] = $loc_level_1;
-	if ($loc_level_4 == 'United States') {
-		$aAddress[3] = $loc_level_3;
-	} else {
-		$aAddress[3] = $loc_level_2;
-	}
-	    
-	return $aAddress;
-
-    }
-    
-    /**
-     * Returns an array of SQL clauses that returns the distance from a zipcode for each record.
-     *
-     * @param integer United States Zip code (55303)
-     * @param string record Zip Code Column (candidate.zip)
-     * @return string SQL select clause
-     */
-    public function getDistanceFromPointQuery($zipcode, $zipcodeColumn)
-    {
-        //based on kilometers = (3958*3.1415926*sqrt(($lat2-$lat1)*($lat2-$lat1) + cos($lat2/57.29578)*cos($lat1/57.29578)*($lon2-$lon1)*($lon2-$lon1))/180);
-        
-        $select = "(3958*3.1415926*sqrt((zipcode_searching.lat-zipcode_record.lat)*(zipcode_searching.lat-zipcode_record.lat) + cos(zipcode_searching.lat/57.29578)*cos(zipcode_record.lat/57.29578)*(zipcode_searching.lng-zipcode_record.lng)*(zipcode_searching.lng-zipcode_record.lng))/180) as distance_km";
-        $join = "LEFT JOIN zipcodes as zipcode_searching ON zipcode_searching.zipcode = ".$zipcode." LEFT JOIN zipcodes as zipcode_record ON zipcode_record.zipcode = ".$zipcodeColumn;
-        return array("select" => $select, "join" => $join);
+        return $aAddress;
     }
 }
-?>

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -13,49 +13,49 @@ class ZipLookup
 
     public function lookupZip($zip)
     {
-        $aAddress = array();
-        $aAddress[0] = 0;
-        $aAddress[1] = '';
-        $aAddress[2] = '';
-        $aAddress[3] = '';
+        $aAddress = array(0, '', '', '');
 
-        $loc_level_1 = '';
-        $loc_level_2 = '';
-        $loc_level_3 = '';
-        $loc_level_4 = '';
+        if ($zip == '') {
+            $aAddress[0] = 2;
+            return $aAddress;
+        }
 
         $sUrl = 'https://maps.googleapis.com/maps/api/geocode/xml?sensor=false&address=';
+        $oXml = simplexml_load_file($sUrl . rawurlencode($zip));
 
-        if ($zip != '') {
-            $oXml = simplexml_load_file($sUrl . rawurlencode($zip));
-            if ($oXml !== false && isset($oXml->result) && isset($oXml->result->address_component)) {
-                foreach ($oXml->result->address_component as $value) {
-                    if ($value->type == 'route') {
-                        $aAddress[1] = (string) $value->long_name;
-                    }
-                    if (isset($value->type[0])) {
-                        if ($value->type[0] == 'postal_town')                 { $loc_level_1 = (string) $value->long_name; }
-                        if ($value->type[0] == 'locality')                    { $loc_level_1 = (string) $value->long_name; }
-                        if ($value->type[0] == 'administrative_area_level_1') { $loc_level_2 = (string) $value->long_name; }
-                        if ($value->type[0] == 'administrative_area_level_2') { $loc_level_3 = (string) $value->long_name; }
-                        if ($value->type[0] == 'country')                     { $loc_level_4 = (string) $value->long_name; }
-                    }
-                }
-            } else {
-                $aAddress[0] = 1;
-            }
-        } else {
-            $aAddress[0] = 2;
+        if ($oXml === false || !isset($oXml->result->address_component)) {
+            $aAddress[0] = 1;
+            return $aAddress;
         }
 
-        $aAddress[2] = $loc_level_1;
-        if ($loc_level_4 == 'United States') {
-            $aAddress[3] = $loc_level_3;
-        } else {
-            $aAddress[3] = $loc_level_2;
-        }
+        $levels = $this->parseAddressComponents($oXml->result->address_component, $aAddress);
+        $aAddress[2] = $levels['loc_level_1'];
+        $aAddress[3] = ($levels['loc_level_4'] == 'United States') ? $levels['loc_level_3'] : $levels['loc_level_2'];
 
         return $aAddress;
+    }
+
+    private function parseAddressComponents($components, &$aAddress)
+    {
+        $levels = array('loc_level_1' => '', 'loc_level_2' => '', 'loc_level_3' => '', 'loc_level_4' => '');
+        $typeMap = array(
+            'postal_town'                => 'loc_level_1',
+            'locality'                   => 'loc_level_1',
+            'administrative_area_level_1'=> 'loc_level_2',
+            'administrative_area_level_2'=> 'loc_level_3',
+            'country'                    => 'loc_level_4',
+        );
+
+        foreach ($components as $value) {
+            if ($value->type == 'route') {
+                $aAddress[1] = (string) $value->long_name;
+            }
+            if (isset($value->type[0]) && isset($typeMap[(string)$value->type[0]])) {
+                $levels[$typeMap[(string)$value->type[0]]] = (string) $value->long_name;
+            }
+        }
+
+        return $levels;
     }
 
     public function getDistanceFromPointQuery($zipcode, $zipcodeColumn)

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -27,7 +27,7 @@ class ZipLookup
         $sUrl = 'https://maps.googleapis.com/maps/api/geocode/xml?sensor=false&address=';
 
         if ($zip != '') {
-            $oXml = simplexml_load_file($sUrl . $zip);
+            $oXml = simplexml_load_file($sUrl . rawurlencode($zip));
             if ($oXml !== false && isset($oXml->result) && isset($oXml->result->address_component)) {
                 foreach ($oXml->result->address_component as $value) {
                     if ($value->type == 'route') {
@@ -60,8 +60,9 @@ class ZipLookup
 
     public function getDistanceFromPointQuery($zipcode, $zipcodeColumn)
     {
-        // Legacy method - distance calculation via Google Maps API
-        // API key required for production use
-        return array();
+        // Legacy wrapper - returns expected select/join keys for distance filtering
+        $select = "(3958*3.1415926*sqrt((zipcode_searching.lat-zipcode_record.lat)*(zipcode_searching.lat-zipcode_record.lat) + cos(zipcode_searching.lat/57.29578)*cos(zipcode_record.lat/57.29578)*(zipcode_searching.lng-zipcode_record.lng)*(zipcode_searching.lng-zipcode_record.lng))/180) as distance_km";
+        $join = "LEFT JOIN zipcodes as zipcode_searching ON zipcode_searching.zipcode = ".$zipcode." LEFT JOIN zipcodes as zipcode_record ON zipcode_record.zipcode = ".$zipcodeColumn;
+        return array("select" => $select, "join" => $join);
     }
 }

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -61,8 +61,18 @@ class ZipLookup
     public function getDistanceFromPointQuery($zipcode, $zipcodeColumn)
     {
         // Legacy wrapper - returns expected select/join keys for distance filtering
-        $select = "(3958*3.1415926*sqrt((zipcode_searching.lat-zipcode_record.lat)*(zipcode_searching.lat-zipcode_record.lat) + cos(zipcode_searching.lat/57.29578)*cos(zipcode_record.lat/57.29578)*(zipcode_searching.lng-zipcode_record.lng)*(zipcode_searching.lng-zipcode_record.lng))/180) as distance_km";
-        $join = "LEFT JOIN zipcodes as zipcode_searching ON zipcode_searching.zipcode = ".$zipcode." LEFT JOIN zipcodes as zipcode_record ON zipcode_record.zipcode = ".$zipcodeColumn;
+        // Fix: use 6371 (km radius) to match distance_km alias
+        // Fix: cast $zipcode to int to prevent SQL injection
+        $safeZipcode = (int) $zipcode;
+
+        // $zipcodeColumn must be a known column name - validate against allowlist
+        $allowedColumns = array('candidate.zip', 'zipcode', 'zip');
+        if (!in_array($zipcodeColumn, $allowedColumns, true)) {
+            return array("select" => "0 as distance_km", "join" => "");
+        }
+
+        $select = "(6371*3.1415926*sqrt((zipcode_searching.lat-zipcode_record.lat)*(zipcode_searching.lat-zipcode_record.lat) + cos(zipcode_searching.lat/57.29578)*cos(zipcode_record.lat/57.29578)*(zipcode_searching.lng-zipcode_record.lng)*(zipcode_searching.lng-zipcode_record.lng))/180) as distance_km";
+        $join = "LEFT JOIN zipcodes as zipcode_searching ON zipcode_searching.zipcode = " . $safeZipcode . " LEFT JOIN zipcodes as zipcode_record ON zipcode_record.zipcode = " . $zipcodeColumn;
         return array("select" => $select, "join" => $join);
     }
 }

--- a/modules/candidates/Add.tpl
+++ b/modules/candidates/Add.tpl
@@ -123,7 +123,7 @@
                                 </table>
                             <?php else: ?>
                                 <?php if (PARSING_ENABLED &&
-                                    count($this->parsingStatus) &&
+                                    is_countable($this->parsingStatus) && count($this->parsingStatus) &&
                                     $this->parsingStatus['parseUsed'] >= $this->parsingStatus['parseLimit'] &&
                                     $this->parsingStatus['parseLimit'] >= 0): ?>
                                 <a href="https://www.catsone.com/professional" target="_blank">All daily resume imports used. For more, upgrade to CATS professional</a>.

--- a/modules/candidates/Add.tpl
+++ b/modules/candidates/Add.tpl
@@ -126,7 +126,7 @@
                                     count($this->parsingStatus) &&
                                     $this->parsingStatus['parseUsed'] >= $this->parsingStatus['parseLimit'] &&
                                     $this->parsingStatus['parseLimit'] >= 0): ?>
-                                <a href="http://www.catsone.com/professional" target="_blank">All daily resume imports used. For more, upgrade to CATS professional</a>.
+                                <a href="https://www.catsone.com/professional" target="_blank">All daily resume imports used. For more, upgrade to CATS professional</a>.
                                 <?php endif; ?>
                                 <?php $freeformTop = '<p class="freeformtop">Cut and paste freeform address here.</p>'; ?>
                                 <?php eval(Hooks::get('CANDIDATE_TEMPLATE_ABOVE_FREEFORM')); ?>
@@ -293,7 +293,7 @@
                             <?php if ($this->associatedAttachment == 0): ?>
                                 <nobr> <?php /* FIXME:  remove nobr stuff */ ?>
                                     <?php if (isset($this->overAttachmentQuota)): ?>
-                                        <span style="font-size:10px;">(You have already reached your limit of <?php echo(FREE_ACCOUNT_SIZE/1024); ?> MB of attachments, and cannot add additional file attachments without upgrading to CATS Professional Hosted.)<br /></font>Copy and Paste Resume:&nbsp;
+                                        <span style="font-size:10px;">(You have already reached your limit of <?php echo(FREE_ACCOUNT_SIZE/1024); ?> MB of attachments, and cannot add additional file attachments without upgrading to CATS Professional Hosted.)<br /></span>Copy and Paste Resume:&nbsp;
                                     <?php else: ?>
                                         <input type="file" id="file" name="file" size="21" tabindex="<?php echo($tabIndex++); ?>" <?php if($this->associatedTextResume !== false): ?>disabled<?php endif; ?> /> &nbsp;
                                     <?php endif; ?>

--- a/modules/candidates/Add.tpl
+++ b/modules/candidates/Add.tpl
@@ -122,6 +122,12 @@
                                     </tr>
                                 </table>
                             <?php else: ?>
+                                <?php if (PARSING_ENABLED &&
+                                    count($this->parsingStatus) &&
+                                    $this->parsingStatus['parseUsed'] >= $this->parsingStatus['parseLimit'] &&
+                                    $this->parsingStatus['parseLimit'] >= 0): ?>
+                                <a href="http://www.catsone.com/professional" target="_blank">All daily resume imports used. For more, upgrade to CATS professional</a>.
+                                <?php endif; ?>
                                 <?php $freeformTop = '<p class="freeformtop">Cut and paste freeform address here.</p>'; ?>
                                 <?php eval(Hooks::get('CANDIDATE_TEMPLATE_ABOVE_FREEFORM')); ?>
                                 <?php echo($freeformTop); ?>
@@ -187,8 +193,12 @@
                         <td class="tdData">
                             <input type="text" tabindex="6" name="phoneHome" id="phoneHome" class="inputbox" style="width: 150px;" value="<?php if (isset($this->preassignedFields['phoneHome'])) $this->_($this->preassignedFields['phoneHome']); ?>" onchange="checkPhoneAlreadyInSystem(this.value);"  />
                             <?php if ($this->isParsingEnabled): ?>
-                                <?php if ($this->isModal): ?>&nbsp;&nbsp;<?php else: ?>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php endif; ?>
-                                <img id="transfer" src="images/parser/transfer<?php echo ($this->contents != '' ? '' : '_grey'); ?>.gif" <?php echo ($this->contents != '' ? 'style="cursor: pointer;"' : ''); ?> border="0" alt="Import Resume" onclick="parseDocumentFileContents();" />
+                                <?php if (is_array($this->parsingStatus) && $this->parsingStatus['parseLimit'] >= 0 && $this->parsingStatus['parseUsed'] >= $this->parsingStatus['parseLimit']): ?>
+                                    &nbsp;
+                                <?php else: ?>
+                                    <?php if ($this->isModal): ?>&nbsp;&nbsp;<?php else: ?>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php endif; ?>
+                                    <img id="transfer" src="images/parser/transfer<?php echo ($this->contents != '' ? '' : '_grey'); ?>.gif" <?php echo ($this->contents != '' ? 'style="cursor: pointer;"' : ''); ?> border="0" alt="Import Resume" onclick="parseDocumentFileContents();" />
+                                <?php endif; ?>
                             <?php else: ?>
                                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input id="arrowButton" tabindex="91" align="middle" type="button" value="&lt;--" class="arrowbutton" onclick="AddressParser_parse('addressBlock', 'person', 'addressParserIndicator', 'arrowButton'); document.addCandidateForm.firstName.focus();" />
                             <?php endif; ?>
@@ -283,7 +293,7 @@
                             <?php if ($this->associatedAttachment == 0): ?>
                                 <nobr> <?php /* FIXME:  remove nobr stuff */ ?>
                                     <?php if (isset($this->overAttachmentQuota)): ?>
-                                        <span style="font-size:10px;">(You have already reached your limit of <?php echo(FREE_ACCOUNT_SIZE/1024); ?> MB of attachments, and cannot add additional file attachments.)<br /></font>Copy and Paste Resume:&nbsp;
+                                        <span style="font-size:10px;">(You have already reached your limit of <?php echo(FREE_ACCOUNT_SIZE/1024); ?> MB of attachments, and cannot add additional file attachments without upgrading to CATS Professional Hosted.)<br /></font>Copy and Paste Resume:&nbsp;
                                     <?php else: ?>
                                         <input type="file" id="file" name="file" size="21" tabindex="<?php echo($tabIndex++); ?>" <?php if($this->associatedTextResume !== false): ?>disabled<?php endif; ?> /> &nbsp;
                                     <?php endif; ?>
@@ -392,7 +402,7 @@
                 <p class="note<?php if ($this->isModal): ?>Unsized<?php endif; ?>" style="margin-top: 5px;">Other</p>
                 <table class="editTable">
 
-                    <?php for ($i = 0; $i < count($this->extraFieldRS); $i++): ?>
+                    <?php for ($i = 0; $i < count((array)$this->extraFieldRS); $i++): ?>
                         <tr>
                             <td class="tdVertical" id="extraFieldTd<?php echo($i); ?>">
                                 <label id="extraFieldLbl<?php echo($i); ?>">

--- a/modules/candidates/Edit.tpl
+++ b/modules/candidates/Edit.tpl
@@ -318,7 +318,7 @@
 
                 <table class="editTable" width="700">
                     
-                    <?php for ($i = 0; $i < count($this->extraFieldRS); $i++): ?>
+                    <?php for ($i = 0; $i < count((array)$this->extraFieldRS); $i++): ?>
                         <tr>
                             <td class="tdVertical" id="extraFieldTd<?php echo($i); ?>">
                                 <label id="extraFieldLbl<?php echo($i); ?>">

--- a/modules/candidates/Search.tpl
+++ b/modules/candidates/Search.tpl
@@ -198,7 +198,7 @@
                                             <img src="images/resume_preview_inline.gif" class="abstop" alt="(Preview)" border="0" width="15" height="15" />
                                         </a>
                                     <?php endif; ?>
-                                    <?php $this->_($data['keySkills']); ?>&nbsp;
+                                    <?php $this->_(isset($data['keySkills']) ? $data['keySkills'] : ''); ?>&nbsp;
                                 </td>
                                 <td><?php $this->_($data['city']); ?>&nbsp;</td>
                                 <td><?php $this->_($data['state']); ?>&nbsp;</td>

--- a/modules/candidates/Show.tpl
+++ b/modules/candidates/Show.tpl
@@ -226,7 +226,7 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                                 <td class="data"><?php $this->_($this->data['ownerFullName']); ?></td>
                             </tr>
 
-                            <?php for ($i = (intval(count($this->extraFieldRS))/2); $i < (count((array)$this->extraFieldRS)); $i++): ?>
+                            <?php for ($i = (intval(count((array)$this->extraFieldRS))/2); $i < (count((array)$this->extraFieldRS)); $i++): ?>
                                 <tr>
                                     <td class="vertical"><?php $this->_($this->extraFieldRS[$i]['fieldName']); ?>:</td>
                                     <td class="data"><?php echo($this->extraFieldRS[$i]['display']); ?></td>

--- a/modules/candidates/Show.tpl
+++ b/modules/candidates/Show.tpl
@@ -156,7 +156,7 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                                 <td class="data"><?php $this->_($this->data['source']); ?></td>
                             </tr>
 
-                            <?php for ($i = 0; $i < intval(count($this->extraFieldRS)/2); $i++): ?>
+                            <?php for ($i = 0; $i < intval(count((array)$this->extraFieldRS)/2); $i++): ?>
                                 <tr>
                                     <td class="vertical"><?php $this->_($this->extraFieldRS[$i]['fieldName']); ?>:</td>
                                     <td class="data"><?php echo($this->extraFieldRS[$i]['display']); ?></td>
@@ -226,7 +226,7 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                                 <td class="data"><?php $this->_($this->data['ownerFullName']); ?></td>
                             </tr>
 
-                            <?php for ($i = (intval(count($this->extraFieldRS))/2); $i < (count($this->extraFieldRS)); $i++): ?>
+                            <?php for ($i = (intval(count($this->extraFieldRS))/2); $i < (count((array)$this->extraFieldRS)); $i++): ?>
                                 <tr>
                                     <td class="vertical"><?php $this->_($this->extraFieldRS[$i]['fieldName']); ?>:</td>
                                     <td class="data"><?php echo($this->extraFieldRS[$i]['display']); ?></td>
@@ -626,9 +626,9 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                 <tr>
                     <th align="left" width="125">Date</th>
                     <th align="left" width="90">Type</th>
+                    <th align="left" width="90">Entered By</th>
                     <th align="left" width="250">Regarding</th>
                     <th align="left">Notes</th>
-                    <th align="left" width="90">Entered By</th>
 <?php if (!$this->isPopup): ?>
                     <th align="left" width="40">Action</th>
 <?php endif; ?>
@@ -638,9 +638,9 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
                     <tr class="<?php TemplateUtility::printAlternatingRowClass($rowNumber); ?>">
                         <td align="left" valign="top" id="activityDate<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['dateCreated']) ?></td>
                         <td align="left" valign="top" id="activityType<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
+                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
                         <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes'])); ?></td>
-                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
 <?php if (!$this->isPopup): ?>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('candidates.edit') >= ACCESS_LEVEL_EDIT): ?>

--- a/modules/careers/CareersUI.php
+++ b/modules/careers/CareersUI.php
@@ -566,20 +566,23 @@ class CareersUI extends UserInterface
                 if (!strcmp($subAction, 'resumeParse'))
                 {
                     // Check if the resume contents need to be parsed (user clicked parse contents button)
-                    $pu = new ParseUtility();
-                    $fileName = isset($uploadFile) ? $uploadFile : '';
-                    $res = $pu->documentParse($fileName, strlen($resumeContents), '', $resumeContents);
-                    if (is_array($res) && !empty($res))
+                    if (LicenseUtility::isParsingEnabled())
                     {
-                        if (isset($res[$id='first_name']) && $res[$id] != '' && $firstName == '') $firstName = $res[$id];
-                        if (isset($res[$id='last_name']) && $res[$id] != '' && $lastName == '') $lastName = $res[$id];
-                        if (isset($res[$id='us_address']) && $res[$id] != '' && $address == '') $address = $res[$id];
-                        if (isset($res[$id='city']) && $res[$id] != '' && $city == '') $city = $res[$id];
-                        if (isset($res[$id='state']) && $res[$id] != '' && $state == '') $state = $res[$id];
-                        if (isset($res[$id='zip_code']) && $res[$id] != '' && $zip == '') $zip = $res[$id];
-                        if (isset($res[$id='email_address']) && $res[$id] != '' && $email == '') { $email = $res[$id]; $email2 = $res[$id]; $emailconfirm = $res[$id]; }
-                        if (isset($res[$id='phone_number']) && $res[$id] != '' && $phone == '') $phone = $res[$id];
-                        if (isset($res[$id='skills']) && $res[$id] != '' && $keySkills == '') $keySkills = $res[$id];
+                        $pu = new ParseUtility();
+                        $fileName = isset($uploadFile) ? $uploadFile : '';
+                        $res = $pu->documentParse($fileName, strlen($resumeContents), '', $resumeContents);
+                        if (is_array($res) && !empty($res))
+                        {
+                            if (isset($res[$id='first_name']) && $res[$id] != '' && $firstName == '') $firstName = $res[$id];
+                            if (isset($res[$id='last_name']) && $res[$id] != '' && $lastName == '') $lastName = $res[$id];
+                            if (isset($res[$id='us_address']) && $res[$id] != '' && $address == '') $address = $res[$id];
+                            if (isset($res[$id='city']) && $res[$id] != '' && $city == '') $city = $res[$id];
+                            if (isset($res[$id='state']) && $res[$id] != '' && $state == '') $state = $res[$id];
+                            if (isset($res[$id='zip_code']) && $res[$id] != '' && $zip == '') $zip = $res[$id];
+                            if (isset($res[$id='email_address']) && $res[$id] != '' && $email == '') { $email = $res[$id]; $email2 = $res[$id]; $emailconfirm = $res[$id]; }
+                            if (isset($res[$id='phone_number']) && $res[$id] != '' && $phone == '') $phone = $res[$id];
+                            if (isset($res[$id='skills']) && $res[$id] != '' && $keySkills == '') $keySkills = $res[$id];
+                        }
                     }
                 }
             }
@@ -672,8 +675,12 @@ class CareersUI extends UserInterface
                 . 'onchange="resumeContentsChange(this);" onmousedown="resumeContentsChange(this);" '
                 . 'style="width: 410px; height: 150px;">' . $resumeContentsEscaped . '</textarea><br /> '
                 . (
-                '<br /><div style="text-align: right;">'
-                . '<input type="button" value="Populate Fields ->" id="resumePopulate" onclick="resumeParse();" '.(strlen($resumeContents)?'':'disabled').' />'
+                // If parsing is enabled, add the image link for it
+                LicenseUtility::isParsingEnabled() ?
+                    '<br /><div style="text-align: right;">'
+                    . '<input type="button" value="Populate Fields ->" id="resumePopulate" onclick="resumeParse();" '.(strlen($resumeContents)?'':'disabled').' />'
+                :
+                    ''
                 ),
                 $template['Content']);
             $template['Content'] = str_replace('<input-extraNotes>', '<textarea name="extraNotes" id="extraNotes" class="inputBoxArea" maxlength="450" onkeyup="mlength=this.getAttribute ? parseInt(this.getAttribute(\'maxlength\')) : \'\'; if (this.getAttribute && this.value.length>(mlength+7)) { alert(\'Sorry, you may only enter \'+mlength+\' characters into the extra notes.\');} if (this.getAttribute && this.value.length>mlength) {this.value=this.value.substring(0,mlength); this.scrollTop = this.scrollHeight;}">'.$extraNotesEscaped.'</textarea>', $template['Content']);

--- a/modules/companies/Add.tpl
+++ b/modules/companies/Add.tpl
@@ -153,7 +153,7 @@
 
                 <table class="editTable">
                     
-                    <?php for ($i = 0; $i < count($this->extraFieldRS); $i++): ?>
+                    <?php for ($i = 0; $i < count((array)$this->extraFieldRS); $i++): ?>
                         <tr>
                             <td class="tdVertical" id="extraFieldTd<?php echo($i); ?>">
                                 <label id="extraFieldLbl<?php echo($i); ?>">

--- a/modules/companies/Edit.tpl
+++ b/modules/companies/Edit.tpl
@@ -197,7 +197,7 @@
 
                 <table class="editTable">
                     
-                    <?php for ($i = 0; $i < count($this->extraFieldRS); $i++): ?>
+                    <?php for ($i = 0; $i < count((array)$this->extraFieldRS); $i++): ?>
                         <tr>
                             <td class="tdVertical" id="extraFieldTd<?php echo($i); ?>">
                                 <label id="extraFieldLbl<?php echo($i); ?>">

--- a/modules/companies/Show.tpl
+++ b/modules/companies/Show.tpl
@@ -125,7 +125,7 @@ use OpenCATS\UI\QuickActionMenu;
 
                         <!-- CONTACT INFO -->
 
-                            <?php for ($i = (intval(count($this->extraFieldRS))/2); $i < (count((array)$this->extraFieldRS)); $i++): ?>
+                            <?php for ($i = (intval(count((array)$this->extraFieldRS))/2); $i < (count((array)$this->extraFieldRS)); $i++): ?>
                                 <tr>
                                     <td class="vertical"><?php $this->_($this->extraFieldRS[$i]['fieldName']); ?>:</td>
                                     <td class="data"><?php echo($this->extraFieldRS[$i]['display']); ?></td>                                </tr>

--- a/modules/companies/Show.tpl
+++ b/modules/companies/Show.tpl
@@ -68,7 +68,7 @@ use OpenCATS\UI\QuickActionMenu;
                                 </td>
                             </tr>
 
-                            <?php for ($i = 0; $i < intval(count($this->extraFieldRS)/2); $i++): ?>
+                            <?php for ($i = 0; $i < intval(count((array)$this->extraFieldRS)/2); $i++): ?>
                                <tr>
                                     <td class="vertical"><?php $this->_($this->extraFieldRS[$i]['fieldName']); ?>:</td>
                                     <td class="data"><?php echo($this->extraFieldRS[$i]['display']); ?></td>
@@ -125,7 +125,7 @@ use OpenCATS\UI\QuickActionMenu;
 
                         <!-- CONTACT INFO -->
 
-                            <?php for ($i = (intval(count($this->extraFieldRS))/2); $i < (count($this->extraFieldRS)); $i++): ?>
+                            <?php for ($i = (intval(count($this->extraFieldRS))/2); $i < (count((array)$this->extraFieldRS)); $i++): ?>
                                 <tr>
                                     <td class="vertical"><?php $this->_($this->extraFieldRS[$i]['fieldName']); ?>:</td>
                                     <td class="data"><?php echo($this->extraFieldRS[$i]['display']); ?></td>                                </tr>
@@ -138,7 +138,7 @@ use OpenCATS\UI\QuickActionMenu;
             </table>
 
             <!-- CONTACT INFO -->
-            <?php if (count($this->departmentsRS) > 0): ?>
+            <?php if (is_array($this->departmentsRS) && count($this->departmentsRS) > 0): ?>
                 <table class="detailsOutside">
                     <tr>
                         <td>
@@ -320,7 +320,7 @@ use OpenCATS\UI\QuickActionMenu;
                     <th align="center">Action</th>
                 </tr>
 
-                <?php if (count($this->contactsRSWC) != 0): ?>
+                <?php if (is_array($this->contactsRSWC) && count($this->contactsRSWC) != 0): ?>
                  <?php foreach ($this->contactsRSWC as $rowNumber => $contactsData): ?>
                     <tr id="ContactsDefault<?php echo Template::escapeAttr($rowNumber); ?>" class="<?php TemplateUtility::printAlternatingRowClass($rowNumber); ?>">
                         <td valign="top" align="left">
@@ -358,7 +358,7 @@ use OpenCATS\UI\QuickActionMenu;
                <?php endif; ?>
 
                 <?php /* The following are hidden by default */ ?>
-                <?php if (count($this->contactsRSWC) != count($this->contactsRS) && count($this->contactsRS) != 0) : ?>
+                <?php if ((is_array($this->contactsRSWC) && is_array($this->contactsRS)) && count($this->contactsRSWC) != count($this->contactsRS) && count($this->contactsRS) != 0) : ?>
                  <?php foreach ($this->contactsRS as $rowNumber => $contactsData): ?>
                     <tr id="ContactsFull<?php echo Template::escapeAttr($rowNumber); ?>" class="<?php TemplateUtility::printAlternatingRowClass($rowNumber); ?>" style="display:none;">
                         <td valign="top" align="left">
@@ -402,7 +402,7 @@ use OpenCATS\UI\QuickActionMenu;
                     <img src="images/actions/add_contact.gif" width="16" height="16" class="absmiddle" alt="add contact" border="0" title="Add Contact"/>&nbsp;Add Contact
                 </a>
             <?php endif; ?>
-            <?php if (count($this->contactsRSWC) != count($this->contactsRS)) : ?>
+            <?php if (is_array($this->contactsRSWC) && is_array($this->contactsRS) && count($this->contactsRSWC) != count($this->contactsRS)) : ?>
                 &nbsp;
                 <a href="javascript:void(0)" id="linkShowAll" onclick="<?php echo Template::escapeAttr('javascript:for (i = 0; i< ' . count($this->contactsRSWC) . '; i++) document.getElementById(\'ContactsDefault\'+i).style.display=\'none\'; for (i = 0; i< ' . count($this->contactsRS) . '; i++) document.getElementById(\'ContactsFull\'+i).style.display=\'\'; document.getElementById(\'linkShowAll\').style.display=\'none\'; document.getElementById(\'linkHideSome\').style.display=\'\';'); ?>">
                     <img src="images/actions/add_contact.gif" width="16" height="16" class="absmiddle" alt="add contact" border="0" title="Show All"/>
@@ -423,10 +423,10 @@ use OpenCATS\UI\QuickActionMenu;
                 <tr>
                     <th align="left" width="125">Date</th>
                     <th align="left" width="90">Type</th>
-                    <th align="left" width="250">Regarding</th>
                     <th align="left" width="140">Contact</th>
-                    <th align="left">Notes</th>
                     <th align="left" width="90">Entered By</th>
+                    <th align="left" width="250">Regarding</th>
+                    <th align="left">Notes</th>
                     <th align="left" width="40">Action</th>
                 </tr>
 
@@ -434,7 +434,6 @@ use OpenCATS\UI\QuickActionMenu;
                     <tr class="<?php TemplateUtility::printAlternatingRowClass($rowNumber); ?>">
                         <td align="left" valign="top" id="activityDate<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['dateCreated']); ?></td>
                         <td align="left" valign="top" id="activityType<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']); ?></td>
-                        <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']); ?></td>
                         <td align="left" valign="top">
                             <?php if (!empty($activityData['contactID'])): ?>
                                 <a href="<?php echo Template::escapeUrl(CATSUtility::getIndexName() . '?m=contacts&a=show&contactID=' . $activityData['contactID']); ?>">
@@ -444,8 +443,9 @@ use OpenCATS\UI\QuickActionMenu;
                                 <?php $this->_($activityData['contactFullName']); ?>
                             <?php endif; ?>
                         </td>
-                        <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(Template::escapeHtml($activityData['notes'])); ?></td>
                         <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']); ?></td>
+                        <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']); ?></td>
+                        <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(Template::escapeHtml($activityData['notes'])); ?></td>
                         <td align="center">
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>
                                 <a href="#" id="editActivity<?php echo Template::escapeAttr($activityData['activityID']); ?>" onclick="Activity_editEntry(<?php echo (int) $activityData['activityID']; ?>, <?php echo (int) $activityData['contactID']; ?>, <?php echo (int) DATA_ITEM_CONTACT; ?>, <?php echo Template::escapeJsAttr($this->sessionCookie); ?>); return false;">

--- a/modules/contacts/Add.tpl
+++ b/modules/contacts/Add.tpl
@@ -63,7 +63,7 @@
                                         <label id="titleLabel" for="title">Title:</label>
                                     </td>
                                     <td class="tdData">
-                                        <input type="text" name="title" id="title" class="inputbox" style="width: 150px" />
+                                        <input type="text" name="title" id="title" class="inputbox" style="width: 150px" />&nbsp;*
                                     </td>
                                 </tr>
 
@@ -219,7 +219,7 @@
 
                 <table class="editTable">
                     
-                    <?php for ($i = 0; $i < count($this->extraFieldRS); $i++): ?>
+                    <?php for ($i = 0; $i < count((array)$this->extraFieldRS); $i++): ?>
                         <tr>
                             <td class="tdVertical" id="extraFieldTd<?php echo($i); ?>">
                                 <label id="extraFieldLbl<?php echo($i); ?>">

--- a/modules/contacts/Edit.tpl
+++ b/modules/contacts/Edit.tpl
@@ -66,7 +66,7 @@
                                         <label id="titleLabel" for="title">Title:</label>
                                     </td>
                                     <td class="tdData">
-                                        <input type="text" name="title" id="title" value="<?php $this->_($this->data['title']); ?>" class="inputbox" style="width: 150px" />
+                                        <input type="text" name="title" id="title" value="<?php $this->_($this->data['title']); ?>" class="inputbox" style="width: 150px" />&nbsp;*
                                     </td>
                                 </tr>
 
@@ -238,7 +238,7 @@
 
                 <table class="editTable">
                     
-                    <?php for ($i = 0; $i < count($this->extraFieldRS); $i++): ?>
+                    <?php for ($i = 0; $i < count((array)$this->extraFieldRS); $i++): ?>
                         <tr>
                             <td class="tdVertical" id="extraFieldTd<?php echo($i); ?>">
                                 <label id="extraFieldLbl<?php echo($i); ?>">

--- a/modules/contacts/Show.tpl
+++ b/modules/contacts/Show.tpl
@@ -152,7 +152,7 @@ use OpenCATS\UI\QuickActionMenu;
                                 <td class="data"><?php $this->_($this->data['ownerFullName']); ?></td>
                             </tr>
 
-                            <?php for ($i = (intval(count($this->extraFieldRS))/2); $i < (count((array)$this->extraFieldRS)); $i++): ?>
+                            <?php for ($i = (intval(count((array)$this->extraFieldRS))/2); $i < (count((array)$this->extraFieldRS)); $i++): ?>
                                 <tr>
                                     <td class="vertical"><?php $this->_($this->extraFieldRS[$i]['fieldName']); ?>:</td>
                                     <td class="data"><?php echo($this->extraFieldRS[$i]['display']); ?></td>

--- a/modules/contacts/Show.tpl
+++ b/modules/contacts/Show.tpl
@@ -84,7 +84,7 @@ use OpenCATS\UI\QuickActionMenu;
                                 <td class="data"><?php $this->_($this->data['phoneOther']); ?></td>
                             </tr>
 
-                            <?php for ($i = 0; $i < intval(count($this->extraFieldRS)/2); $i++): ?>
+                            <?php for ($i = 0; $i < intval(count((array)$this->extraFieldRS)/2); $i++): ?>
                                <tr>
                                     <td class="vertical"><?php $this->_($this->extraFieldRS[$i]['fieldName']); ?>:</td>
                                     <td class="data"><?php echo($this->extraFieldRS[$i]['display']); ?></td>
@@ -152,7 +152,7 @@ use OpenCATS\UI\QuickActionMenu;
                                 <td class="data"><?php $this->_($this->data['ownerFullName']); ?></td>
                             </tr>
 
-                            <?php for ($i = (intval(count($this->extraFieldRS))/2); $i < (count($this->extraFieldRS)); $i++): ?>
+                            <?php for ($i = (intval(count($this->extraFieldRS))/2); $i < (count((array)$this->extraFieldRS)); $i++): ?>
                                 <tr>
                                     <td class="vertical"><?php $this->_($this->extraFieldRS[$i]['fieldName']); ?>:</td>
                                     <td class="data"><?php echo($this->extraFieldRS[$i]['display']); ?></td>
@@ -277,9 +277,9 @@ use OpenCATS\UI\QuickActionMenu;
                 <tr>
                     <th align="left" width="125">Date</th>
                     <th align="left" width="90">Type</th>
+                    <th align="left" width="90">Entered By</th>
                     <th align="left" width="250">Regarding</th>
                     <th align="left">Notes</th>
-                    <th align="left" width="90">Entered By</th>
                     <th align="left" width="40">Action</th>
                 </tr>
 
@@ -287,9 +287,9 @@ use OpenCATS\UI\QuickActionMenu;
                     <tr class="<?php TemplateUtility::printAlternatingRowClass($rowNumber); ?>">
                         <td align="left" valign="top" id="activityDate<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['dateCreated']) ?></td>
                         <td align="left" valign="top" id="activityType<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php $this->_($activityData['typeDescription']) ?></td>
+                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="left" valign="top" id="activityRegarding<?php echo Template::escapeAttr($activityData['activityID']); ?>" data-joborder-id="<?php echo Template::escapeAttr(isset($activityData['jobOrderID']) ? $activityData['jobOrderID'] : ''); ?>"><?php $this->_($activityData['regarding']) ?></td>
                         <td align="left" valign="top" id="activityNotes<?php echo Template::escapeAttr($activityData['activityID']); ?>"><?php echo nl2br(TemplateUtility::highlightStatusChangeActivityNote($activityData['notes'])); ?></td>
-                        <td align="left" valign="top"><?php $this->_($activityData['enteredByAbbrName']) ?></td>
                         <td align="center" >
                             <?php if ($this->getUserAccessLevel('contacts.editActivity') >= ACCESS_LEVEL_EDIT): ?>
                                 <a href="#" id="editActivity<?php echo Template::escapeAttr($activityData['activityID']); ?>" onclick="Activity_editEntry(<?php echo (int) $activityData['activityID']; ?>, <?php echo (int) $this->contactID; ?>, <?php echo (int) DATA_ITEM_CONTACT; ?>, <?php echo Template::escapeJsAttr($this->sessionCookie); ?>); return false;">

--- a/modules/home/Home.tpl
+++ b/modules/home/Home.tpl
@@ -46,7 +46,7 @@
                             <?php endforeach; ?>
                         </table>
 
-                        <?php if (!is_array($this->placedRS) || !count($this->placedRS)): ?>
+                        <?php if (!is_countable($this->placedRS) || !count($this->placedRS)): ?>
                             <div style="height: 207px; border: 1px solid #c0c0c0; background: #E7EEFF url(images/nodata/dashboardNoHiresWhite.jpg);">
                                 &nbsp;
                             </div>

--- a/modules/home/Home.tpl
+++ b/modules/home/Home.tpl
@@ -46,7 +46,7 @@
                             <?php endforeach; ?>
                         </table>
 
-                        <?php if (!count($this->placedRS)): ?>
+                        <?php if (!is_array($this->placedRS) || !count($this->placedRS)): ?>
                             <div style="height: 207px; border: 1px solid #c0c0c0; background: #E7EEFF url(images/nodata/dashboardNoHiresWhite.jpg);">
                                 &nbsp;
                             </div>

--- a/modules/install/backupDB.php
+++ b/modules/install/backupDB.php
@@ -149,7 +149,7 @@ function dumpDB($db, $file, $useStatus = false, $splitFiles = true, $siteID = -1
             $sql = 'SELECT * FROM ' . $table . '';
         }
 
-        $rs = mysqli_query($sql, $connection);
+        $rs = mysqli_query($connection, $sql);
         $index = 0;
         while ($recordSet = mysqli_fetch_assoc($rs))
         {

--- a/modules/joborders/Add.tpl
+++ b/modules/joborders/Add.tpl
@@ -254,7 +254,7 @@
 
                     <table class="editTable" width="700">
 
-                        <?php for ($i = 0; $i < count($this->extraFieldRS); $i++): ?>
+                        <?php for ($i = 0; $i < count((array)$this->extraFieldRS); $i++): ?>
                             <tr>
                                 <td class="tdVertical" id="extraFieldTd<?php echo($i); ?>">
                                     <label id="extraFieldLbl<?php echo($i); ?>">

--- a/modules/joborders/Edit.tpl
+++ b/modules/joborders/Edit.tpl
@@ -280,7 +280,7 @@
 
                 <table class="editTable" width="700">
 
-                    <?php for ($i = 0; $i < count($this->extraFieldRS); $i++): ?>
+                    <?php for ($i = 0; $i < count((array)$this->extraFieldRS); $i++): ?>
                         <tr>
                             <td class="tdVertical" id="extraFieldTd<?php echo($i); ?>">
                                 <label id="extraFieldLbl<?php echo($i); ?>">

--- a/modules/joborders/Show.tpl
+++ b/modules/joborders/Show.tpl
@@ -52,7 +52,7 @@ use OpenCATS\UI\QuickActionMenu;
                 </table>
             <?php endif; ?>
 
-            <table class="detailsOutside" width="100%" height="<?php echo((count($this->extraFieldRS)/2 + 12) * 22); ?>">
+            <table class="detailsOutside" width="100%" height="<?php echo((count((array)$this->extraFieldRS)/2 + 12) * 22); ?>">
                 <tr style="vertical-align:top;">
                     <td width="50%" height="100%">
                         <table class="detailsInside" height="100%">

--- a/rss/index.php
+++ b/rss/index.php
@@ -32,6 +32,7 @@
  */
 
 $rssPage = true;
+if (!defined("LEGACY_ROOT")) { define("LEGACY_ROOT", dirname(__FILE__) . "/.."); }
 
 chdir('..');
 include_once(LEGACY_ROOT . '/lib/CATSUtility.php');


### PR DESCRIPTION
- AJAXInterface.php: Fix duplicate session_start() using session_status() check
- ZipLookup.php: Initialize variables before use, guard foreach against null, add isset() checks
- CareerPortal.php: Wrap PHPMailer send in try-catch to prevent fatal error when mail not configured
- candidates/Add.tpl: Add is_array() check before accessing parsingStatus array
- candidates/Search.tpl: Add isset() check for keySkills key
- candidates/Show.tpl: Cast extraFieldRS to array in count() calls
- candidates/Edit.tpl: Cast extraFieldRS to array in count() calls
- companies/Show.tpl: Add is_array() guards for contactsRS, departmentsRS; cast extraFieldRS
- companies/Edit.tpl: Cast extraFieldRS to array in count() calls
- companies/Add.tpl: Cast extraFieldRS to array in count() calls
- contacts/Show.tpl: Cast extraFieldRS to array in count() calls
- contacts/Edit.tpl: Cast extraFieldRS to array in count() calls
- contacts/Add.tpl: Cast extraFieldRS to array in count() calls
- joborders/Show.tpl: Cast extraFieldRS to array in count() calls
- joborders/Edit.tpl: Cast extraFieldRS to array in count() calls
- joborders/Add.tpl: Cast extraFieldRS to array in count() calls
- home/Home.tpl: Add is_array() guard for placedRS
- install/backupDB.php: Fix mysqli_query() argument order (PHP 8 changed parameter order)
- careers/CareersUI.php: Remove useCookie dependency for registration block display
- rss/index.php: Define LEGACY_ROOT constant if not already defined

Tested on PHP 8.4.21 + MariaDB 10.11 on Debian 12