### PR TITLE
feat: add configurable 12-hour and 24-hour time formats

### DIFF
--- a/ajax/editActivity.php
+++ b/ajax/editActivity.php
@@ -80,7 +80,6 @@ $activityNote = trim(urldecode($_POST['notes']));
 $activityDate = trim(urldecode($_POST['date']));
 $activityHour = trim(urldecode($_POST['hour']));
 $activityMinute = trim(urldecode($_POST['minute']));
-$activityAMPM = trim(urldecode($_POST['ampm']));
 
 $dateFormatFlag = $_SESSION['CATS']->isDateDMY()
     ? DATE_FORMAT_DDMMYY
@@ -99,19 +98,17 @@ if ($jobOrderID === null || $jobOrderID === '' || $jobOrderID === 'NULL' ||
     $jobOrderID = -1;
 }
 
-/* Convert formatted time to UNIX timestamp. */
-$time = strtotime(
-    sprintf('%02d:%02d %s', $activityHour, $activityMinute, $activityAMPM)
-);
+/* Convert time fields to a 'HH:MM:SS' string. */
+$is24 = $_SESSION['CATS']->isTimeFormat24();
+$activityAMPM = $is24 ? '' : trim(urldecode($_POST['ampm']));
+$timeStr = DateUtility::normalizeActivityTime($activityHour, $activityMinute, $activityAMPM, $is24);
+if ($timeStr === false)
+{
+    die('Invalid time.');
+}
 
 /* Create MySQL date string w/ 24hr time (YYYY-MM-DD HH:MM:SS). */
-$date = sprintf(
-    '%s %s',
-    DateUtility::convert(
-        '-', $activityDate, $dateFormatFlag, DATE_FORMAT_YYYYMMDD
-    ),
-    date('H:i:00', $time)
-);
+$date = DateUtility::convert('-', $activityDate, $dateFormatFlag, DATE_FORMAT_YYYYMMDD) . ' ' . $timeStr;
 
 /* Save the new activity entry. */
 $activityEntries = new ActivityEntries();

--- a/installwizard.php
+++ b/installwizard.php
@@ -481,6 +481,17 @@
                                                     </td>
                                                 </tr>
                                                 <tr>
+                                                    <td>Please choose your preferred time format.</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <select id="timeFormat" name="timeFormat" style="width: 150px;" class="selectBox">
+                                                            <option value="12" selected="selected">12-hour (1:30 PM)</option>
+                                                            <option value="24">24-hour (13:30)</option>
+                                                        </select>
+                                                    </td>
+                                                </tr>
+                                                <tr>
                                                     <td>Please enter your default phone country calling code.</td>
                                                 </tr>
                                                 <tr>

--- a/js/activity.js
+++ b/js/activity.js
@@ -296,31 +296,46 @@ function Activity_editEntry(activityID, dataItemID, dataItemType, sessionCookie)
         var userDateFormat = (typeof window.CATSUserDateFormat !== "undefined" ? window.CATSUserDateFormat : "MM-DD-YY");
         dateSpan.innerHTML = DateInputForDOM("dateEditActivity" + activityID, true, userDateFormat, dateAndTime.substr(0,dateAndTime.indexOf(" ")), -1);
 
-        var timeString = dateAndTime.substr(dateAndTime.indexOf(" ")+2);
-        var hourString = timeString.substr(0,timeString.indexOf(":"));
-        var timeString = timeString.substr(timeString.indexOf(":")+1);
-        var minuteString = timeString.substr(0,timeString.indexOf(" "));
-        var timeString = timeString.substr(timeString.indexOf(" ")+1);
-        var amPmString = timeString.substr(0,timeString.indexOf(")"));
-        
-        /* Time editor. */
+        /* Parse time from display string: strip date prefix and the opening "(". */
+        var timeSection = dateAndTime.substr(dateAndTime.indexOf("(") + 1);
+        var hourString, minuteString, amPmString;
+        if (window.CATSTimeFormat24)
+        {
+            /* 24-hour display: "(HH:MM)" */
+            hourString   = timeSection.substr(0, timeSection.indexOf(":"));
+            minuteString = timeSection.substr(timeSection.indexOf(":") + 1, 2);
+            amPmString   = "";
+        }
+        else
+        {
+            /* 12-hour display: "(H:MM AM)" or "(H:MM PM)" */
+            hourString   = timeSection.substr(0, timeSection.indexOf(":"));
+            var rest     = timeSection.substr(timeSection.indexOf(":") + 1);
+            minuteString = rest.substr(0, rest.indexOf(" "));
+            amPmString   = rest.substr(rest.indexOf(" ") + 1, 2);
+        }
+
+        /* Time editor — hour select. */
         var hourSelect = document.createElement("select");
         hourSelect.setAttribute("id", "hourEditActivity" + activityID);
-        for (var i = 1; i<= 12; ++i)
+        var hourMin = window.CATSTimeFormat24 ? 0 : 1;
+        var hourMax = window.CATSTimeFormat24 ? 23 : 12;
+        for (var i = hourMin; i <= hourMax; ++i)
         {
             var hourSelectOption = document.createElement("option");
             hourSelectOption.value = i;
-            hourSelectOption.innerHTML = i;
+            hourSelectOption.innerHTML = window.CATSTimeFormat24 ? (i < 10 ? '0' + i : '' + i) : i;
             if (hourString * 1 == i)
             {
                 hourSelectOption.selected = true;
             }
             hourSelect.appendChild(hourSelectOption);
         }
-        
+
+        /* Time editor — minute select. */
         var minuteSelect = document.createElement("select");
         minuteSelect.setAttribute("id", "minuteEditActivity" + activityID);
-        for (var i = 0; i<= 59; ++i)
+        for (var i = 0; i <= 59; ++i)
         {
             var minuteSelectOption = document.createElement("option");
             minuteSelectOption.value = i;
@@ -331,37 +346,45 @@ function Activity_editEntry(activityID, dataItemID, dataItemType, sessionCookie)
             }
             minuteSelect.appendChild(minuteSelectOption);
         }
-        
-        var AMPMSelect = document.createElement("select");
-        AMPMSelect.setAttribute("id", "ampmEditActivity" + activityID);
-        
-        var AMPMSelectOptionAM = document.createElement("option");
-        AMPMSelectOptionAM.value = "AM";
-        AMPMSelectOptionAM.innerHTML = "AM";
-        if (amPmString == "AM")
+
+        /* Time editor — AM/PM select (12-hour mode only). */
+        var AMPMSelect = null;
+        if (!window.CATSTimeFormat24)
         {
-            AMPMSelectOptionAM.selected = true;
+            AMPMSelect = document.createElement("select");
+            AMPMSelect.setAttribute("id", "ampmEditActivity" + activityID);
+
+            var AMPMSelectOptionAM = document.createElement("option");
+            AMPMSelectOptionAM.value = "AM";
+            AMPMSelectOptionAM.innerHTML = "AM";
+            if (amPmString == "AM")
+            {
+                AMPMSelectOptionAM.selected = true;
+            }
+            AMPMSelect.appendChild(AMPMSelectOptionAM);
+
+            var AMPMSelectOptionPM = document.createElement("option");
+            AMPMSelectOptionPM.value = "PM";
+            AMPMSelectOptionPM.innerHTML = "PM";
+            if (amPmString == "PM")
+            {
+                AMPMSelectOptionPM.selected = true;
+            }
+            AMPMSelect.appendChild(AMPMSelectOptionPM);
         }
-        AMPMSelect.appendChild(AMPMSelectOptionAM);
-        
-        var AMPMSelectOptionPM = document.createElement("option");
-        AMPMSelectOptionPM.value = "PM";
-        AMPMSelectOptionPM.innerHTML = "PM";
-        if (amPmString == "PM")
-        {
-            AMPMSelectOptionPM.selected = true;
-        }
-        AMPMSelect.appendChild(AMPMSelectOptionPM);
-        
+
         var dateTimeTable = document.createElement("table");
         var dateTimeTableTr = document.createElement("tr");
         var dateTimeTableTdLeft = document.createElement("td");
         var dateTimeTableTdRight = document.createElement("td");
-        
-        dateTimeTableTdLeft.appendChild(dateSpan);    
-        dateTimeTableTdRight.appendChild(hourSelect);    
-        dateTimeTableTdRight.appendChild(minuteSelect); 
-        dateTimeTableTdRight.appendChild(AMPMSelect);    
+
+        dateTimeTableTdLeft.appendChild(dateSpan);
+        dateTimeTableTdRight.appendChild(hourSelect);
+        dateTimeTableTdRight.appendChild(minuteSelect);
+        if (AMPMSelect)
+        {
+            dateTimeTableTdRight.appendChild(AMPMSelect);
+        }
         dateTimeTableTr.appendChild(dateTimeTableTdLeft);
         dateTimeTableTr.appendChild(dateTimeTableTdRight);
         dateTimeTable.appendChild(dateTimeTableTr);
@@ -390,7 +413,7 @@ function Activity_editEntry(activityID, dataItemID, dataItemType, sessionCookie)
                 document.getElementById("dateEditActivity" + activityID).value,
                 document.getElementById("hourEditActivity" + activityID).value,
                 document.getElementById("minuteEditActivity" + activityID).value,
-                document.getElementById("ampmEditActivity" + activityID).value,
+                AMPMSelect ? AMPMSelect.value : "",
                 oldEditRow,
                 newEditRow,
                 activityID,
@@ -861,6 +884,10 @@ function AS_onEventAllDayChange(allDayRadioID)
 
     document.getElementById("hour").disabled = disableTime;
     document.getElementById("minute").disabled = disableTime;
-    document.getElementById("meridiem").disabled = disableTime;
+    var meridiem = document.getElementById("meridiem");
+    if (meridiem)
+    {
+        meridiem.disabled = disableTime;
+    }
     document.getElementById("duration").disabled = disableTime;
 }

--- a/js/wizardIntro.js
+++ b/js/wizardIntro.js
@@ -91,10 +91,12 @@ function extendedNext()
         // This is the localization page
         var timeZone = document.getElementById("timeZone");
         var dateFormat = document.getElementById("dateFormat");
+        var timeFormatEl = document.getElementById("timeFormat");
+        var timeFormat = timeFormatEl ? timeFormatEl.value : "12";
         failAction = "alert(\"Unable to set your localization settings! Please try again.\");";
         userActionSuccess = "funcNext();";
         failAction = "";
-        userAction("Localization&timeZone=" + escape(timeZone.value) + "&dateFormat=" + escape(dateFormat.value));
+        userAction("Localization&timeZone=" + escape(timeZone.value) + "&dateFormat=" + escape(dateFormat.value) + "&timeFormat=" + escape(timeFormat));
         return false;
     }
 

--- a/lib/ActivityEntries.php
+++ b/lib/ActivityEntries.php
@@ -63,11 +63,15 @@ include_once(LEGACY_ROOT . '/lib/JobOrders.php');
 class ActivityEntries
 {
     private $_db;
+    private $_mysqlDateTimeFormat;
 
 
     public function __construct()
     {
         $this->_db = DatabaseConnection::getInstance();
+
+        $is24 = (isset($_SESSION['CATS']) && $_SESSION['CATS']->isTimeFormat24());
+        $this->_mysqlDateTimeFormat = DateUtility::getMysqlDateTimeFormat($is24);
     }
 
 
@@ -405,7 +409,7 @@ class ActivityEntries
                 activity_type.short_description AS typeDescription,
                 activity.notes AS notes,
                 DATE_FORMAT(
-                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '" . $this->_mysqlDateTimeFormat . "'
                 ) AS dateCreated,
                 entered_by_user.first_name AS enteredByFirstName,
                 entered_by_user.last_name AS enteredByLastName,
@@ -450,7 +454,7 @@ class ActivityEntries
                 activity.joborder_id AS jobOrderID,
                 activity.notes AS notes,
                 DATE_FORMAT(
-                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '" . $this->_mysqlDateTimeFormat . "'
                 ) AS dateCreated,
                 activity.date_occurred AS dateCreatedSort,
                 activity.type AS type,
@@ -503,7 +507,7 @@ class ActivityEntries
                 activity.joborder_id AS jobOrderID,
                 activity.notes AS notes,
                 DATE_FORMAT(
-                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '" . $this->_mysqlDateTimeFormat . "'
                 ) AS dateCreated,
                 activity.date_occurred AS dateCreatedSort,
                 activity.type AS type,

--- a/lib/Attachments.php
+++ b/lib/Attachments.php
@@ -487,7 +487,7 @@ class Attachments
                 directory_name AS directoryName,
                 md5_sum AS md5sum,
                 file_size_kb AS fileSizeKB,
-                DATE_FORMAT(date_created, '%%m-%%d-%%y (%%h:%%i:%%s %%p)') AS dateCreated
+                DATE_FORMAT(date_created, '" . DateUtility::getMysqlDateTimeSecondsFormat() . "') AS dateCreated
             FROM
                 attachment
             WHERE
@@ -550,7 +550,7 @@ class Attachments
                 directory_name AS directoryName,
                 md5_sum AS md5sum,
                 file_size_kb AS fileSizeKB,
-                DATE_FORMAT(date_created, '%%m-%%d-%%y (%%h:%%i:%%s %%p)') AS dateCreated
+                DATE_FORMAT(date_created, '" . DateUtility::getMysqlDateTimeSecondsFormat() . "') AS dateCreated
             FROM
                 attachment
             WHERE

--- a/lib/Calendar.php
+++ b/lib/Calendar.php
@@ -109,7 +109,7 @@ class Calendar
                     calendar_event.date, '%%m-%%d-%%y'
                 ) AS date,
                 DATE_FORMAT(
-                    calendar_event.date, '%%h:%%i %%p'
+                    calendar_event.date, '" . DateUtility::getMysqlTimeFormat() . "'
                 ) AS time,
                 DATE_FORMAT(
                     calendar_event.date, '%%H'
@@ -119,7 +119,7 @@ class Calendar
                 ) AS minute,
                 calendar_event.date AS dateSort,
                 DATE_FORMAT(
-                    calendar_event.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    calendar_event.date_created, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateCreated,
                 calendar_event_type.calendar_event_type_id AS eventType,
                 calendar_event_type.short_description AS eventTypeDescription,
@@ -608,7 +608,7 @@ class Calendar
                 calendar_event.description AS description,
                 calendar_event.public AS public,
                 DATE_FORMAT(
-                    calendar_event.date, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    calendar_event.date, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateShow,
                 DATE_FORMAT(
                     calendar_event.date, '%%d'
@@ -705,7 +705,7 @@ class Calendar
                     calendar_event.date, '%%m-%%d-%%y'
                 ) AS date,
                 DATE_FORMAT(
-                    calendar_event.date, '%%h:%%i %%p'
+                    calendar_event.date, '" . DateUtility::getMysqlTimeFormat() . "'
                 ) AS time,
                 calendar_event.date AS dateSort,
                 entered_by_user.user_id AS userID,
@@ -752,7 +752,7 @@ class Calendar
                     calendar_event.date, '%%m-%%d-%%y'
                 ) AS date,
                 DATE_FORMAT(
-                    calendar_event.date, '%%h:%%i %%p'
+                    calendar_event.date, '" . DateUtility::getMysqlTimeFormat() . "'
                 ) AS time,
                 calendar_event.date AS dateSort,
                 entered_by_user.user_id AS userID,

--- a/lib/Candidates.php
+++ b/lib/Candidates.php
@@ -537,10 +537,10 @@ class Candidates
                 candidate.is_hot AS isHot,
                 candidate.is_admin_hidden AS isAdminHidden,
                 DATE_FORMAT(
-                    candidate.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    candidate.date_created, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateCreated,
                 DATE_FORMAT(
-                    candidate.date_modified, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    candidate.date_modified, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateModified,
                 COUNT(
                     candidate_joborder.joborder_id

--- a/lib/Companies.php
+++ b/lib/Companies.php
@@ -374,7 +374,7 @@ class Companies
                     billing_contact.first_name, ' ', billing_contact.last_name
                 ) AS billingContactFullName,
                 DATE_FORMAT(
-                    company.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    company.date_created, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateCreated,
                 CONCAT(
                     entered_by_user.first_name, ' ', entered_by_user.last_name

--- a/lib/Contacts.php
+++ b/lib/Contacts.php
@@ -528,10 +528,10 @@ class Contacts
                 reportsToContact.title as reportsToTitle,
                 company_department.name AS department,
                 DATE_FORMAT(
-                    contact.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    contact.date_created, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateCreated,
                 DATE_FORMAT(
-                    contact.date_modified, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    contact.date_modified, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateModified,
                 company.name AS companyName,
                 company.is_hot AS isHotCompany,
@@ -659,7 +659,7 @@ class Contacts
                     contact.date_created, '%%m-%%d-%%y'
                 ) AS dateCreated,
                 DATE_FORMAT(
-                    contact.date_modified, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    contact.date_modified, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateModified,
                 owner_user.first_name AS ownerFirstName,
                 owner_user.last_name AS ownerLastName,

--- a/lib/DateUtility.php
+++ b/lib/DateUtility.php
@@ -387,7 +387,136 @@ class DateUtility
 
         return date($format, $unixTime);
     }
-    
+
+    /**
+     * Returns the PHP time format string for the configured time format.
+     * Pass an explicit boolean to override the session value (useful in tests).
+     *
+     * @param boolean|null $isTimeFormat24  true=24h, false=12h, null=read from session
+     * @return string 'H:i' for 24-hour or 'g:i A' for 12-hour
+     */
+    public static function getTimeFormat($isTimeFormat24 = null)
+    {
+        if ($isTimeFormat24 === null)
+        {
+            $isTimeFormat24 = (isset($_SESSION['CATS']) && $_SESSION['CATS']->isTimeFormat24());
+        }
+
+        return $isTimeFormat24 ? 'H:i' : 'g:i A';
+    }
+
+    /**
+     * Returns a combined date + time PHP format string for the configured formats.
+     *
+     * @param string       $dateFormat      A PHP date format string for the date portion.
+     * @param boolean|null $isTimeFormat24  true=24h, false=12h, null=read from session
+     * @return string combined format, e.g. 'm-d-Y g:i A' or 'm-d-Y H:i'
+     */
+    public static function getDateTimeFormat($dateFormat, $isTimeFormat24 = null)
+    {
+        return $dateFormat . ' ' . self::getTimeFormat($isTimeFormat24);
+    }
+
+    /**
+     * Returns the MySQL DATE_FORMAT time-only format string for use inside
+     * a PHP sprintf() call (% signs are already doubled).
+     * 24-hour: '%%H:%%i' becomes MySQL %H:%i (e.g. 13:30)
+     * 12-hour: '%%h:%%i %%p' becomes MySQL %h:%i %p (e.g. 01:30 PM)
+     *
+     * @param boolean|null $isTimeFormat24  true=24h, false=12h, null=session
+     * @return string sprintf-escaped MySQL time format string
+     */
+    public static function getMysqlTimeFormat($isTimeFormat24 = null)
+    {
+        if ($isTimeFormat24 === null)
+        {
+            $isTimeFormat24 = (isset($_SESSION['CATS']) && $_SESSION['CATS']->isTimeFormat24());
+        }
+        return $isTimeFormat24 ? '%%H:%%i' : '%%h:%%i %%p';
+    }
+
+    /**
+     * Returns the MySQL DATE_FORMAT date+time format string for use inside
+     * a PHP sprintf() call (% signs are already doubled).
+     * 24-hour: '%%m-%%d-%%y (%%H:%%i)'
+     * 12-hour: '%%m-%%d-%%y (%%h:%%i %%p)'
+     *
+     * @param boolean|null $isTimeFormat24  true=24h, false=12h, null=session
+     * @return string sprintf-escaped MySQL datetime format string
+     */
+    public static function getMysqlDateTimeFormat($isTimeFormat24 = null)
+    {
+        if ($isTimeFormat24 === null)
+        {
+            $isTimeFormat24 = (isset($_SESSION['CATS']) && $_SESSION['CATS']->isTimeFormat24());
+        }
+        return $isTimeFormat24 ? '%%m-%%d-%%y (%%H:%%i)' : '%%m-%%d-%%y (%%h:%%i %%p)';
+    }
+
+    /**
+     * Returns the MySQL DATE_FORMAT date+time+seconds format string for use
+     * inside a PHP sprintf() call (% signs are already doubled).
+     * 24-hour: '%%m-%%d-%%y (%%H:%%i:%%s)'
+     * 12-hour: '%%m-%%d-%%y (%%h:%%i:%%s %%p)'
+     *
+     * @param boolean|null $isTimeFormat24  true=24h, false=12h, null=session
+     * @return string sprintf-escaped MySQL datetime+seconds format string
+     */
+    public static function getMysqlDateTimeSecondsFormat($isTimeFormat24 = null)
+    {
+        if ($isTimeFormat24 === null)
+        {
+            $isTimeFormat24 = (isset($_SESSION['CATS']) && $_SESSION['CATS']->isTimeFormat24());
+        }
+        return $isTimeFormat24 ? '%%m-%%d-%%y (%%H:%%i:%%s)' : '%%m-%%d-%%y (%%h:%%i:%%s %%p)';
+    }
+
+    /**
+     * Normalizes activity form time inputs to a 'HH:MM:00' string suitable
+     * for storage.  Returns false when inputs are out of range.
+     *
+     * In 24-hour mode $hour must be 0-23; $meridiem is ignored.
+     * In 12-hour mode $hour must be 1-12 and $meridiem must be 'AM' or 'PM'.
+     *
+     * @param integer $hour      Hour from the form
+     * @param integer $minute    Minute from the form (0-59)
+     * @param string  $meridiem  'AM' or 'PM' (ignored in 24-hour mode)
+     * @param boolean $is24      true for 24-hour mode
+     * @return string|false 'HH:MM:00' on success, false on invalid input
+     */
+    public static function normalizeActivityTime($hour, $minute, $meridiem, $is24)
+    {
+        $hour   = (int) $hour;
+        $minute = (int) $minute;
+
+        if ($minute < 0 || $minute > 59)
+        {
+            return false;
+        }
+
+        if ($is24)
+        {
+            if ($hour < 0 || $hour > 23)
+            {
+                return false;
+            }
+            return sprintf('%02d:%02d:00', $hour, $minute);
+        }
+
+        if ($hour < 1 || $hour > 12 || ($meridiem !== 'AM' && $meridiem !== 'PM'))
+        {
+            return false;
+        }
+
+        $hour24 = $hour % 12;   /* 12 AM becomes 0; 1-11 AM stay 1-11. */
+        if ($meridiem === 'PM')
+        {
+            $hour24 += 12;       /* 12 PM stays 12; 1-11 PM become 13-23. */
+        }
+
+        return sprintf('%02d:%02d:00', $hour24, $minute);
+    }
+
     /**
      * Returns a human readable representation of a period of time in seconds.
      *

--- a/lib/EmailTemplates.php
+++ b/lib/EmailTemplates.php
@@ -260,7 +260,7 @@ class EmailTemplates
         if ($isLoggedIn)
         {
             $replacementStrings = array(
-                DateUtility::getAdjustedDate($dateFormat . ' g:i A'),
+                DateUtility::getAdjustedDate(DateUtility::getDateTimeFormat($dateFormat)),
                 $siteName,
                 $fullName,
                 '<a href="mailto:'. $email .'">'. $email .'</a>'
@@ -277,8 +277,9 @@ class EmailTemplates
 
             $siteName = $siteRS['name'];
 
+            $is24 = !empty($siteRS['timeFormat24']);
             $replacementStrings = array(
-                DateUtility::getAdjustedDate($dateFormat . ' g:i A'),
+                DateUtility::getAdjustedDate(DateUtility::getDateTimeFormat($dateFormat, $is24)),
                 $siteName,
                 '',
                 '<a href="mailto:' . $email . '">' . $email . '</a>'

--- a/lib/History.php
+++ b/lib/History.php
@@ -266,7 +266,7 @@ class History
                     entered_by_user.first_name, ' ', entered_by_user.last_name
                 ) AS enteredByFullName,
                 DATE_FORMAT(
-                    set_date, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    set_date, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateModified
             FROM
                 history

--- a/lib/JobOrders.php
+++ b/lib/JobOrders.php
@@ -461,10 +461,10 @@ class JobOrders
                     NOW(), joborder.date_created
                 ) AS daysOld,
                 DATE_FORMAT(
-                    joborder.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    joborder.date_created, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateCreated,
                 DATE_FORMAT(
-                    joborder.date_modified, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    joborder.date_modified, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateModified,
                 COUNT(
                     candidate_joborder.joborder_id

--- a/lib/LoginActivity.php
+++ b/lib/LoginActivity.php
@@ -117,7 +117,7 @@ class LoginActivityPager extends Pager
                 user_login.ip AS ip,
                 user_login.user_agent AS shortUserAgent,
                 DATE_FORMAT(
-                    user_login.date, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    user_login.date, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS date,
                 user_login.date AS dateSort,
                 user_login.host AS hostname,

--- a/lib/Pipelines.php
+++ b/lib/Pipelines.php
@@ -709,7 +709,7 @@ class Pipelines
                 candidate_joborder.rating_value AS ratingValue,
                 entered_by_user.first_name AS enteredByFirstName,
                 entered_by_user.last_name AS enteredByLastName,
-                DATE_FORMAT(activity.date_modified, '%%m-%%d-%%y (%%h:%%i:%%s %%p)') AS dateModified
+                DATE_FORMAT(activity.date_modified, '" . DateUtility::getMysqlDateTimeSecondsFormat() . "') AS dateModified
             FROM
                 candidate_joborder
             LEFT JOIN candidate

--- a/lib/Session.php
+++ b/lib/Session.php
@@ -71,6 +71,7 @@ class CATSSession
     private $_timeZone = 0;
     private $_defaultPhoneCountryCode = '+1';
     private $_dateDMY = false;
+    private $_timeFormat24 = false;
     private $_pipelineEntriesPerPage = 15;
     private $_storedData = array();
     private $_storedValues = array();
@@ -357,6 +358,17 @@ class CATSSession
         return $this->_dateDMY;
     }
 
+    /**
+     * Returns true if 24-hour time format is configured for the current site,
+     * false otherwise (12-hour format). The database is not accessed.
+     *
+     * @return boolean Is 24-hour time format in use?
+     */
+    public function isTimeFormat24()
+    {
+        return $this->_timeFormat24;
+    }
+
     // FIXME: Document me!
     public function getAccessLevel($securedObjectName)
     {
@@ -569,13 +581,14 @@ class CATSSession
      * @param boolean Display dates in D-M-Y format?
      * @return void
      */
-    public function setTimeDateLocalization($timeZone, $isDMY)
+    public function setTimeDateLocalization($timeZone, $isDMY, $isTimeFormat24 = false)
     {
         $timeZone = (integer) $timeZone;
 
         $this->_timeZone       = $timeZone;
         $this->_timeZoneOffset = $timeZone - OFFSET_GMT;
         $this->_dateDMY        = $isDMY;
+        $this->_timeFormat24   = (bool) $isTimeFormat24;
     }
 
     /**
@@ -648,6 +661,7 @@ class CATSSession
                 site.time_zone AS timeZone,
                 site.default_phone_country_code AS defaultPhoneCountryCode,
                 site.date_format_ddmmyy AS dateFormatDMY,
+                site.time_format_24 AS timeFormat24,
                 site.is_free AS isFree,
                 site.is_hr_mode AS isHrMode,
                 site.first_time_setup as isFirstTimeSetup,
@@ -774,6 +788,7 @@ class CATSSession
                 $this->_timeZone               = $rs['timeZone'];
                 $this->_defaultPhoneCountryCode = $rs['defaultPhoneCountryCode'];
                 $this->_dateDMY                = ($rs['dateFormatDMY'] == 0 ? false : true);
+                $this->_timeFormat24           = ($rs['timeFormat24'] == 0 ? false : true);
                 $this->_canSeeEEOInfo          = ($rs['canSeeEEOInfo'] == 0 ? false : true);
                 $this->_pipelineEntriesPerPage = $rs['pipelineEntriesPerPage'];
                 $this->_loggedInScript         = CATSUtility::getDirectoryName(); 

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -70,18 +70,21 @@ class Site
      *
      * @param integer time zone offset
      * @param boolean use D-M-Y format dates
+     * @param boolean use 24-hour time format
      * @return boolean True if successful; false otherwise.
      */
-    public function setLocalization($timeZone, $isDMY)
+    public function setLocalization($timeZone, $isDMY, $isTimeFormat24 = false)
     {
         $sql = sprintf(
             "UPDATE
                 site
             SET
                 time_zone = %s,
-                date_format_ddmmyy = %s",
+                date_format_ddmmyy = %s,
+                time_format_24 = %s",
             $this->_db->makeQueryInteger($timeZone),
-            ($isDMY ? 1 : 0)
+            ($isDMY ? 1 : 0),
+            ($isTimeFormat24 ? 1 : 0)
         );
 
         return (boolean) $this->_db->query($sql);

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -123,7 +123,8 @@ class Site
                 user_licenses AS userLicenses,
                 entered_by AS enteredBy,
                 unix_name AS unixName,
-                date_format_ddmmyy as dateFormatDDMMYY
+                date_format_ddmmyy as dateFormatDDMMYY,
+                time_format_24 AS timeFormat24
             FROM
                 site
             WHERE

--- a/lib/Statistics.php
+++ b/lib/Statistics.php
@@ -279,7 +279,7 @@ class Statistics
                     owner_user.first_name, ' ', owner_user.last_name
                 ) AS ownerFullName,
                 DATE_FORMAT(
-                    candidate_joborder_status_history.date, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    candidate_joborder_status_history.date, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateSubmitted
             FROM
                 candidate_joborder_status_history
@@ -377,7 +377,7 @@ class Statistics
                     owner_user.first_name, ' ', owner_user.last_name
                 ) AS ownerFullName,
                 DATE_FORMAT(
-                    candidate_joborder_status_history.date, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    candidate_joborder_status_history.date, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateSubmitted
             FROM
                 candidate_joborder_status_history
@@ -571,7 +571,7 @@ class Statistics
                     owner_user.first_name, ' ', owner_user.last_name
                 ) AS ownerFullName,
                 DATE_FORMAT(
-                    joborder.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    joborder.date_created, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateCreated,
                 COUNT(
                     candidate_joborder.joborder_id

--- a/lib/TemplateUtility.php
+++ b/lib/TemplateUtility.php
@@ -907,8 +907,9 @@ class TemplateUtility
     {
         $build = $_SESSION['CATS']->getCachedBuild();
 
-        // FIXME: LOCAL TIME ZONE!
-        $date  = date('l, F jS, Y \a\t h:i:s A T');
+        $isTimeFormat24 = isset($_SESSION['CATS']) && $_SESSION['CATS']->isTimeFormat24();
+        $timeFormat = $isTimeFormat24 ? 'H:i:s' : 'g:i:s A';
+        $date = DateUtility::getAdjustedDate('l, F jS, Y \a\t ' . $timeFormat . ' T');
 
         if ($build > 0)
         {

--- a/lib/Users.php
+++ b/lib/Users.php
@@ -285,13 +285,13 @@ class Users
                         MAX(
                             IF(user_login.successful = 1, user_login.date, NULL)
                            ),
-                        '%%m-%%d-%%y (%%h:%%i %%p)'
+                        '" . DateUtility::getMysqlDateTimeFormat() . "'
                         ) AS successfulDate,
                 DATE_FORMAT(
                         MAX(
                             IF(user_login.successful = 0, user_login.date, NULL)
                            ),
-                        '%%m-%%d-%%y (%%h:%%i %%p)'
+                        '" . DateUtility::getMysqlDateTimeFormat() . "'
                         ) AS unsuccessfulDate,
                 force_logout as forceLogout
                     FROM
@@ -349,13 +349,13 @@ class Users
                         MAX(
                             IF(user_login.successful = 1, user_login.date, NULL)
                            ),
-                        '%%m-%%d-%%y (%%h:%%i %%p)'
+                        '" . DateUtility::getMysqlDateTimeFormat() . "'
                         ) AS successfulDate,
                 DATE_FORMAT(
                         MAX(
                             IF(user_login.successful = 0, user_login.date, NULL)
                            ),
-                        '%%m-%%d-%%y (%%h:%%i %%p)'
+                        '" . DateUtility::getMysqlDateTimeFormat() . "'
                         ) AS unsuccessfulDate,
                 force_logout as forceLogout
                     FROM
@@ -464,13 +464,13 @@ class Users
                     MAX(
                         IF(user_login.successful = 1, user_login.date, NULL)
                        ),
-                    '%%m-%%d-%%y (%%h:%%i %%p)'
+                    '" . DateUtility::getMysqlDateTimeFormat() . "'
                     ) AS successfulDate,
                 DATE_FORMAT(
                         MAX(
                             IF(user_login.successful = 0, user_login.date, NULL)
                            ),
-                        '%%m-%%d-%%y (%%h:%%i %%p)'
+                        '" . DateUtility::getMysqlDateTimeFormat() . "'
                         ) AS unsuccessfulDate
                     FROM
                     user
@@ -1100,7 +1100,7 @@ class Users
                 user.first_name AS firstName,
                 user.last_name AS lastName,
                 DATE_FORMAT(
-                    user_login.date_refreshed, '%%h:%%i %%p'
+                    user_login.date_refreshed, '" . DateUtility::getMysqlTimeFormat() . "'
                     ) AS lastRefresh,
                 IF(
                     user_login.date_refreshed > DATE_SUB(NOW(), INTERVAL 20 SECOND),

--- a/modules/activity/AddActivityScheduleEventModal.tpl
+++ b/modules/activity/AddActivityScheduleEventModal.tpl
@@ -35,9 +35,15 @@
                 </td>
                 <td class="tdData">
                     <select id="activityHour" name="activityHour" class="inputbox" style="width: 40px;">
-                        <?php for ($i = 1; $i <= 12; ++$i): ?>
-                            <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
-                        <?php endfor; ?>
+                        <?php if ($_SESSION['CATS']->isTimeFormat24()): ?>
+                            <?php for ($i = 0; $i <= 23; ++$i): ?>
+                                <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                            <?php endfor; ?>
+                        <?php else: ?>
+                            <?php for ($i = 1; $i <= 12; ++$i): ?>
+                                <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                            <?php endfor; ?>
+                        <?php endif; ?>
                     </select>&nbsp;
                     <select id="activityMinute" name="activityMinute" class="inputbox" style="width: 40px;">
                         <?php for ($i = 0; $i <= 59; ++$i): ?>
@@ -46,10 +52,12 @@
                             </option>
                         <?php endfor; ?>
                     </select>&nbsp;
+                    <?php if (!$_SESSION['CATS']->isTimeFormat24()): ?>
                     <select id="activityMeridiem" name="activityMeridiem" class="inputbox" style="width: 45px;">
                         <option value="AM">AM</option>
                         <option value="PM">PM</option>
                     </select>
+                    <?php endif; ?>
                 </td>
             </tr>
 <?php endif; ?>
@@ -125,9 +133,15 @@
                                     <div style="margin-bottom: 4px;">
                                         <input type="radio" name="allDay" id="allDay0" value="0" style="margin-left: 0px" checked="checked" onchange="AS_onEventAllDayChange('allDay1');" />
                                         <select id="hour" name="hour" class="inputbox" style="width: 40px;">
-                                            <?php for ($i = 1; $i <= 12; ++$i): ?>
-                                                <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
-                                            <?php endfor; ?>
+                                            <?php if ($_SESSION['CATS']->isTimeFormat24()): ?>
+                                                <?php for ($i = 0; $i <= 23; ++$i): ?>
+                                                    <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                                                <?php endfor; ?>
+                                            <?php else: ?>
+                                                <?php for ($i = 1; $i <= 12; ++$i): ?>
+                                                    <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                                                <?php endfor; ?>
+                                            <?php endif; ?>
                                         </select>&nbsp;
                                         <select id="minute" name="minute" class="inputbox" style="width: 40px;">
                                             <?php for ($i = 0; $i <= 45; $i = $i + 15): ?>
@@ -136,10 +150,12 @@
                                                 </option>
                                             <?php endfor; ?>
                                         </select>&nbsp;
+                                        <?php if (!$_SESSION['CATS']->isTimeFormat24()): ?>
                                         <select id="meridiem" name="meridiem" class="inputbox" style="width: 45px;">
                                             <option value="AM">AM</option>
                                             <option value="PM">PM</option>
                                         </select>
+                                        <?php endif; ?>
                                     </div>
 
                                     <div style="margin-bottom: 4px;">
@@ -217,14 +233,15 @@
         if (!<?php echo($this->onlyScheduleEvent ? 'true' : 'false'); ?>)
         {
             var now = new Date();
+            <?php if ($_SESSION['CATS']->isTimeFormat24()): ?>
+            document.getElementById('activityHour').value = now.getHours().toString();
+            <?php else: ?>
             var currentHour = now.getHours() % 12;
-            if (currentHour == 0)
-            {
-                currentHour = 12;
-            }
+            if (currentHour == 0) { currentHour = 12; }
             document.getElementById('activityHour').value = currentHour.toString();
-            document.getElementById('activityMinute').value = (now.getMinutes() < 10 ? '0' : '') + now.getMinutes();
             document.getElementById('activityMeridiem').value = (now.getHours() >= 12 ? 'PM' : 'AM');
+            <?php endif; ?>
+            document.getElementById('activityMinute').value = (now.getMinutes() < 10 ? '0' : '') + now.getMinutes();
             document.logActivityForm.activityNote.focus();
         }
 <?php if ($this->onlyScheduleEvent && $this->activityFocusEventTitle): ?>

--- a/modules/activity/dataGrids.php
+++ b/modules/activity/dataGrids.php
@@ -200,7 +200,7 @@ class ActivityDataGrid extends DataGrid
                 activity.notes AS notes,
                 activity_type.short_description AS typeDescription,
                 DATE_FORMAT(
-                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateCreated,
                 activity.date_occurred AS dateCreatedSort,
                 entered_by_user.first_name AS enteredByFirstName,
@@ -246,7 +246,7 @@ class ActivityDataGrid extends DataGrid
                 activity.notes AS notes,
                 activity_type.short_description AS typeDescription,
                 DATE_FORMAT(
-                    activity.date_occurred, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    activity.date_occurred, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateCreated,
                 activity.date_occurred AS dateCreatedSort,
                 entered_by_user.first_name AS enteredByFirstName,

--- a/modules/calendar/Calendar.tpl
+++ b/modules/calendar/Calendar.tpl
@@ -4,6 +4,7 @@
 <?php TemplateUtility::printTabs($this->active); ?>
     <script type="text/javascript">
         window.CATSUserDateFormat = '<?php echo($_SESSION['CATS']->isDateDMY() ? 'DD-MM-YY' : 'MM-DD-YY'); ?>';
+        window.CATSTimeFormat24 = <?php echo($_SESSION['CATS']->isTimeFormat24() ? 'true' : 'false'); ?>;
     </script>
     <div id="main">
         <?php TemplateUtility::printQuickSearch(); ?>
@@ -98,9 +99,15 @@
                                                 <td class="tdData">
                                                     <input type="radio" name="allDay" id="allDay0" value="0" checked onchange="setAddAllDayEnabled();" />
                                                     <select id="hour" name="hour" class="inputbox" style="width: 40px;">
-                                                        <?php for ($i = 1; $i <= 12; ++$i): ?>
-                                                            <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
-                                                        <?php endfor; ?>
+                                                        <?php if ($_SESSION['CATS']->isTimeFormat24()): ?>
+                                                            <?php for ($i = 0; $i <= 23; ++$i): ?>
+                                                                <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                                                            <?php endfor; ?>
+                                                        <?php else: ?>
+                                                            <?php for ($i = 1; $i <= 12; ++$i): ?>
+                                                                <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                                                            <?php endfor; ?>
+                                                        <?php endif; ?>
                                                     </select>&nbsp;
                                                     <select id="minute" name="minute" class="inputbox" style="width: 40px;">
                                                         <?php for ($i = 0; $i <= 45; $i = $i + 15): ?>
@@ -109,10 +116,12 @@
                                                             </option>
                                                         <?php endfor; ?>
                                                     </select>&nbsp;
+                                                    <?php if (!$_SESSION['CATS']->isTimeFormat24()): ?>
                                                     <select id="meridiem" name="meridiem" class="inputbox" style="width: 45px;">
                                                         <option value="AM">AM</option>
                                                         <option value="PM">PM</option>
                                                     </select>
+                                                    <?php endif; ?>
                                                     <br />
 
                                                     <input type="radio" name="allDay" id="allDay1" value="1" onchange="setAddAllDayEnabled();" />All Day / No Specific Time<br />
@@ -248,9 +257,15 @@
                                                 <td class="tdData">
                                                     <input type="radio" name="allDay" id="allDayEdit0" value="0" checked onchange="setEditAllDayEnabled();" />
                                                     <select id="hourEdit" name="hour" class="inputbox" style="width: 40px;">
-                                                        <?php for ($i = 1; $i <= 12; ++$i): ?>
-                                                            <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
-                                                        <?php endfor; ?>
+                                                        <?php if ($_SESSION['CATS']->isTimeFormat24()): ?>
+                                                            <?php for ($i = 0; $i <= 23; ++$i): ?>
+                                                                <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                                                            <?php endfor; ?>
+                                                        <?php else: ?>
+                                                            <?php for ($i = 1; $i <= 12; ++$i): ?>
+                                                                <option value="<?php echo($i); ?>"><?php echo(sprintf('%02d', $i)); ?></option>
+                                                            <?php endfor; ?>
+                                                        <?php endif; ?>
                                                     </select>&nbsp;
                                                     <select id="minuteEdit" name="minute" class="inputbox" style="width: 40px;">
                                                         <?php for ($i = 0; $i <= 45; $i = $i + 15): ?>
@@ -259,10 +274,12 @@
                                                             </option>
                                                         <?php endfor; ?>
                                                     </select>&nbsp;
+                                                    <?php if (!$_SESSION['CATS']->isTimeFormat24()): ?>
                                                     <select id="meridiemEdit" name="meridiem" class="inputbox" style="width: 45px;">
                                                         <option value="AM">AM</option>
                                                         <option value="PM">PM</option>
                                                     </select>
+                                                    <?php endif; ?>
                                                     <br />
 
                                                     <input type="radio" name="allDay" id="allDayEdit1" value="1" onchange="setEditAllDayEnabled();" />All Day / No Specific Time<br />

--- a/modules/calendar/CalendarUI.js
+++ b/modules/calendar/CalendarUI.js
@@ -199,24 +199,31 @@ function calendarEditEvent(entry)
         setCheckedValue(document.getElementById("editEventForm").elements["allDay"], "0");
         setEditAllDayEnabled();
 
-        if (entry.hour > 12)
+        if (window.CATSTimeFormat24)
         {
-            document.getElementById("hourEdit").value = entry.hour - 12;
+            document.getElementById("hourEdit").value = entry.hour;
         }
         else
         {
-            if (entry.hour == 0)
+            if (entry.hour > 12)
             {
-                document.getElementById("hourEdit").value = 12;
+                document.getElementById("hourEdit").value = entry.hour - 12;
             }
             else
             {
-                document.getElementById("hourEdit").value = entry.hour * 1;
+                if (entry.hour == 0)
+                {
+                    document.getElementById("hourEdit").value = 12;
+                }
+                else
+                {
+                    document.getElementById("hourEdit").value = entry.hour * 1;
+                }
             }
-        }
-        if (entry.hour >= 12)
-        {
-            document.getElementById("meridiemEdit").value = "PM";
+            if (entry.hour >= 12)
+            {
+                document.getElementById("meridiemEdit").value = "PM";
+            }
         }
 
         var string = "" + entry.minute;
@@ -388,25 +395,31 @@ function addEventByDay(year, month, day, hour)
 
     document.getElementById("publicEntry").checked = defaultPublic;
 
-    if (hour > 12)
+    if (window.CATSTimeFormat24)
     {
-        document.getElementById("hour").value = hour - 12;
+        document.getElementById("hour").value = hour;
     }
     else
     {
-        if (hour == 0)
+        if (hour > 12)
         {
-            document.getElementById("hour").value = 12;
+            document.getElementById("hour").value = hour - 12;
         }
         else
         {
-            document.getElementById("hour").value = hour;
+            if (hour == 0)
+            {
+                document.getElementById("hour").value = 12;
+            }
+            else
+            {
+                document.getElementById("hour").value = hour;
+            }
         }
-    }
-
-    if (hour >= 12)
-    {
-        document.getElementById("meridiem").value = "PM";
+        if (hour >= 12)
+        {
+            document.getElementById("meridiem").value = "PM";
+        }
     }
 
     //cleanUpUI();
@@ -514,7 +527,8 @@ function setAddAllDayEnabled()
 
     document.getElementById("hour").disabled = state;
     document.getElementById("minute").disabled = state;
-    document.getElementById("meridiem").disabled = state;
+    var mer = document.getElementById("meridiem");
+    if (mer) { mer.disabled = state; }
     document.getElementById("duration").disabled = state;
 }
 
@@ -529,7 +543,8 @@ function setEditAllDayEnabled()
 
     document.getElementById("hourEdit").disabled = state;
     document.getElementById("minuteEdit").disabled = state;
-    document.getElementById("meridiemEdit").disabled = state;
+    var merEdit = document.getElementById("meridiemEdit");
+    if (merEdit) { merEdit.disabled = state; }
     document.getElementById("durationEdit").disabled = state;
 }
 

--- a/modules/calendar/CalendarUI.php
+++ b/modules/calendar/CalendarUI.php
@@ -421,10 +421,6 @@ class CalendarUI extends UserInterface
             $date = DateUtility::convert(
                 '-', $trimmedDate, $dateFormatFlag, DATE_FORMAT_YYYYMMDD
             );
-
-            $hour = 12;
-            $minute = 0;
-            $meridiem = 'AM';
         }
         else
         {
@@ -440,21 +436,29 @@ class CalendarUI extends UserInterface
                 CommonErrors::fatal(COMMONERROR_BADFIELDS, $this, 'Invalid minute.');
             }
 
-            /* Bail out if we don't have a valid meridiem value. */
-            if (!isset($_POST['meridiem']) ||
-                ($_POST['meridiem'] != 'AM' && $_POST['meridiem'] != 'PM'))
+            $hour   = $_POST['hour'];
+            $minute = $_POST['minute'];
+
+            if ($_SESSION['CATS']->isTimeFormat24())
             {
-                CommonErrors::fatal(COMMONERROR_BADFIELDS, $this, 'Invalid meridiem value.');
+                $time = strtotime(sprintf('%02d:%02d', $hour, $minute));
             }
+            else
+            {
+                /* Bail out if we don't have a valid meridiem value. */
+                if (!isset($_POST['meridiem']) ||
+                    ($_POST['meridiem'] != 'AM' && $_POST['meridiem'] != 'PM'))
+                {
+                    CommonErrors::fatal(COMMONERROR_BADFIELDS, $this, 'Invalid meridiem value.');
+                }
 
-            $hour     = $_POST['hour'];
-            $minute   = $_POST['minute'];
-            $meridiem = $_POST['meridiem'];
+                $meridiem = $_POST['meridiem'];
 
-            /* Convert formatted time to UNIX timestamp. */
-            $time = strtotime(
-                sprintf('%s:%s %s', $hour, $minute, $meridiem)
-            );
+                /* Convert formatted time to UNIX timestamp. */
+                $time = strtotime(
+                    sprintf('%s:%s %s', $hour, $minute, $meridiem)
+                );
+            }
 
             /* Create MySQL date string w/ 24hr time (YYYY-MM-DD HH:MM:SS). */
             $date = sprintf(
@@ -627,10 +631,6 @@ class CalendarUI extends UserInterface
             $date = DateUtility::convert(
                 '-', $trimmedDate, $dateFormatFlag, DATE_FORMAT_YYYYMMDD
             );
-
-            $hour = 12;
-            $minute = 0;
-            $meridiem = 'AM';
         }
         else
         {
@@ -646,21 +646,29 @@ class CalendarUI extends UserInterface
                 CommonErrors::fatal(COMMONERROR_BADFIELDS, $this, 'Invalid minute.');
             }
 
-            /* Bail out if we don't have a valid meridiem value. */
-            if (!isset($_POST['meridiem']) ||
-                ($_POST['meridiem'] != 'AM' && $_POST['meridiem'] != 'PM'))
+            $hour   = $_POST['hour'];
+            $minute = $_POST['minute'];
+
+            if ($_SESSION['CATS']->isTimeFormat24())
             {
-                CommonErrors::fatal(COMMONERROR_BADFIELDS, $this, 'Invalid meridiem value.');
+                $time = strtotime(sprintf('%02d:%02d', $hour, $minute));
             }
+            else
+            {
+                /* Bail out if we don't have a valid meridiem value. */
+                if (!isset($_POST['meridiem']) ||
+                    ($_POST['meridiem'] != 'AM' && $_POST['meridiem'] != 'PM'))
+                {
+                    CommonErrors::fatal(COMMONERROR_BADFIELDS, $this, 'Invalid meridiem value.');
+                }
 
-            $hour     = $_POST['hour'];
-            $minute   = $_POST['minute'];
-            $meridiem = $_POST['meridiem'];
+                $meridiem = $_POST['meridiem'];
 
-            /* Convert formatted time to UNIX timestamp. */
-            $time = strtotime(
-                sprintf('%s:%s %s', $hour, $minute, $meridiem)
-            );
+                /* Convert formatted time to UNIX timestamp. */
+                $time = strtotime(
+                    sprintf('%s:%s %s', $hour, $minute, $meridiem)
+                );
+            }
 
             /* Create MySQL date string w/ 24hr time (YYYY-MM-DD HH:MM:SS). */
             $date = sprintf(

--- a/modules/candidates/CandidatesUI.php
+++ b/modules/candidates/CandidatesUI.php
@@ -3176,41 +3176,30 @@ class CandidatesUI extends UserInterface
             $activityNote = $this->getTrimmedInput('activityNote', $_POST);
 
             $activityDateOccurred = false;
+            $isTimeFormat24 = $_SESSION['CATS']->isTimeFormat24();
             $dateFormatFlag = $_SESSION['CATS']->isDateDMY()
                 ? DATE_FORMAT_DDMMYY
                 : DATE_FORMAT_MMDDYY;
             $activityDate = $this->getTrimmedInput('activityDate', $_POST);
+            $activityHourSet = isset($_POST['activityHour']) && isset($_POST['activityMinute']) &&
+                ctype_digit((string) $_POST['activityHour']) &&
+                ctype_digit((string) $_POST['activityMinute']);
+            $activityMeridiemOk = $isTimeFormat24 ||
+                (isset($_POST['activityMeridiem']) &&
+                 ($_POST['activityMeridiem'] == 'AM' || $_POST['activityMeridiem'] == 'PM'));
             if (!empty($activityDate) &&
                 DateUtility::validate('-', $activityDate, $dateFormatFlag) &&
-                isset($_POST['activityHour']) && isset($_POST['activityMinute']) &&
-                isset($_POST['activityMeridiem']) &&
-                ctype_digit((string) $_POST['activityHour']) &&
-                ctype_digit((string) $_POST['activityMinute']) &&
-                ($_POST['activityMeridiem'] == 'AM' || $_POST['activityMeridiem'] == 'PM'))
+                $activityHourSet && $activityMeridiemOk)
             {
-                $activityHour = (int) $_POST['activityHour'];
-                $activityMinute = (int) $_POST['activityMinute'];
-
-                if ($activityHour >= 1 && $activityHour <= 12 &&
-                    $activityMinute >= 0 && $activityMinute <= 59)
+                $activityMeridiem = $isTimeFormat24 ? '' : (isset($_POST['activityMeridiem']) ? $_POST['activityMeridiem'] : '');
+                $timeStr = DateUtility::normalizeActivityTime(
+                    $_POST['activityHour'], $_POST['activityMinute'], $activityMeridiem, $isTimeFormat24
+                );
+                if ($timeStr !== false)
                 {
-                    $activityHour = $activityHour % 12;
-                    if ($_POST['activityMeridiem'] == 'PM')
-                    {
-                        $activityHour += 12;
-                    }
-
-                    $activityDateOccurred = sprintf(
-                        '%s %02d:%02d:00',
-                        DateUtility::convert(
-                            '-',
-                            $activityDate,
-                            $dateFormatFlag,
-                            DATE_FORMAT_YYYYMMDD
-                        ),
-                        $activityHour,
-                        $activityMinute
-                    );
+                    $activityDateOccurred = DateUtility::convert(
+                        '-', $activityDate, $dateFormatFlag, DATE_FORMAT_YYYYMMDD
+                    ) . ' ' . $timeStr;
                 }
             }
 
@@ -3306,23 +3295,31 @@ class CandidatesUI extends UserInterface
                     CommonErrors::fatalModal(COMMONERROR_MISSINGFIELDS, $this, 'Invalid minute.');
                 }
 
-                /* Bail out if we don't have a valid meridiem value. */
-                if (!isset($_POST['meridiem']) ||
-                    ($_POST['meridiem'] != 'AM' && $_POST['meridiem'] != 'PM'))
+                $hour   = $_POST['hour'];
+                $minute = $_POST['minute'];
+
+                if ($_SESSION['CATS']->isTimeFormat24())
                 {
-                    $this->fatalModal(
-                        'Invalid meridiem value.', $moduleDirectory
+                    $time = strtotime(sprintf('%02d:%02d', $hour, $minute));
+                }
+                else
+                {
+                    /* Bail out if we don't have a valid meridiem value. */
+                    if (!isset($_POST['meridiem']) ||
+                        ($_POST['meridiem'] != 'AM' && $_POST['meridiem'] != 'PM'))
+                    {
+                        $this->fatalModal(
+                            'Invalid meridiem value.', $moduleDirectory
+                        );
+                    }
+
+                    $meridiem = $_POST['meridiem'];
+
+                    /* Convert formatted time to UNIX timestamp. */
+                    $time = strtotime(
+                        sprintf('%s:%s %s', $hour, $minute, $meridiem)
                     );
                 }
-
-                $hour     = $_POST['hour'];
-                $minute   = $_POST['minute'];
-                $meridiem = $_POST['meridiem'];
-
-                /* Convert formatted time to UNIX timestamp. */
-                $time = strtotime(
-                    sprintf('%s:%s %s', $hour, $minute, $meridiem)
-                );
 
                 /* Create MySQL date string w/ 24hr time (YYYY-MM-DD HH:MM:SS). */
                 $date = sprintf(

--- a/modules/candidates/Show.tpl
+++ b/modules/candidates/Show.tpl
@@ -15,7 +15,8 @@ use OpenCATS\UI\CandidateDuplicateQuickActionMenu;
 <?php endif; ?>
 
         <script type="text/javascript">
-            window.CATSUserDateFormat = <?php echo Template::escapeJs($_SESSION['CATS']->isDateDMY() ? 'DD-MM-YY' : 'MM-DD-YY'); ?>;
+            window.CATSUserDateFormat  = <?php echo Template::escapeJs($_SESSION['CATS']->isDateDMY() ? 'DD-MM-YY' : 'MM-DD-YY'); ?>;
+            window.CATSTimeFormat24    = <?php echo $_SESSION['CATS']->isTimeFormat24() ? 'true' : 'false'; ?>;
         </script>
 
         <div id="contents">

--- a/modules/companies/Show.tpl
+++ b/modules/companies/Show.tpl
@@ -5,6 +5,10 @@ use OpenCATS\UI\QuickActionMenu;
 <?php TemplateUtility::printHeader('Company - ' . $this->data['name'], array( 'js/activity.js', 'js/sorttable.js', 'js/attachment.js')); ?>
 <?php TemplateUtility::printHeaderBlock(); ?>
 <?php TemplateUtility::printTabs($this->active); ?>
+    <script type="text/javascript">
+        window.CATSUserDateFormat  = <?php echo Template::escapeJs($_SESSION['CATS']->isDateDMY() ? 'DD-MM-YY' : 'MM-DD-YY'); ?>;
+        window.CATSTimeFormat24    = <?php echo $_SESSION['CATS']->isTimeFormat24() ? 'true' : 'false'; ?>;
+    </script>
     <div id="main">
         <?php TemplateUtility::printQuickSearch(); ?>
 

--- a/modules/contacts/ContactsUI.php
+++ b/modules/contacts/ContactsUI.php
@@ -1398,41 +1398,30 @@ class ContactsUI extends UserInterface
             $activityNote = $this->getTrimmedInput('activityNote', $_POST);
 
             $activityDateOccurred = false;
+            $isTimeFormat24 = $_SESSION['CATS']->isTimeFormat24();
             $dateFormatFlag = $_SESSION['CATS']->isDateDMY()
                 ? DATE_FORMAT_DDMMYY
                 : DATE_FORMAT_MMDDYY;
             $activityDate = $this->getTrimmedInput('activityDate', $_POST);
+            $activityHourSet = isset($_POST['activityHour']) && isset($_POST['activityMinute']) &&
+                ctype_digit((string) $_POST['activityHour']) &&
+                ctype_digit((string) $_POST['activityMinute']);
+            $activityMeridiemOk = $isTimeFormat24 ||
+                (isset($_POST['activityMeridiem']) &&
+                 ($_POST['activityMeridiem'] == 'AM' || $_POST['activityMeridiem'] == 'PM'));
             if (!empty($activityDate) &&
                 DateUtility::validate('-', $activityDate, $dateFormatFlag) &&
-                isset($_POST['activityHour']) && isset($_POST['activityMinute']) &&
-                isset($_POST['activityMeridiem']) &&
-                ctype_digit((string) $_POST['activityHour']) &&
-                ctype_digit((string) $_POST['activityMinute']) &&
-                ($_POST['activityMeridiem'] == 'AM' || $_POST['activityMeridiem'] == 'PM'))
+                $activityHourSet && $activityMeridiemOk)
             {
-                $activityHour = (int) $_POST['activityHour'];
-                $activityMinute = (int) $_POST['activityMinute'];
-
-                if ($activityHour >= 1 && $activityHour <= 12 &&
-                    $activityMinute >= 0 && $activityMinute <= 59)
+                $activityMeridiem = $isTimeFormat24 ? '' : (isset($_POST['activityMeridiem']) ? $_POST['activityMeridiem'] : '');
+                $timeStr = DateUtility::normalizeActivityTime(
+                    $_POST['activityHour'], $_POST['activityMinute'], $activityMeridiem, $isTimeFormat24
+                );
+                if ($timeStr !== false)
                 {
-                    $activityHour = $activityHour % 12;
-                    if ($_POST['activityMeridiem'] == 'PM')
-                    {
-                        $activityHour += 12;
-                    }
-
-                    $activityDateOccurred = sprintf(
-                        '%s %02d:%02d:00',
-                        DateUtility::convert(
-                            '-',
-                            $activityDate,
-                            $dateFormatFlag,
-                            DATE_FORMAT_YYYYMMDD
-                        ),
-                        $activityHour,
-                        $activityMinute
-                    );
+                    $activityDateOccurred = DateUtility::convert(
+                        '-', $activityDate, $dateFormatFlag, DATE_FORMAT_YYYYMMDD
+                    ) . ' ' . $timeStr;
                 }
             }
 
@@ -1529,21 +1518,29 @@ class ContactsUI extends UserInterface
                     CommonErrors::fatalModal(COMMONERROR_MISSINGFIELDS, $this, 'Invalid minute.');
                 }
 
-                /* Bail out if we don't have a valid meridiem value. */
-                if (!isset($_POST['meridiem']) ||
-                    ($_POST['meridiem'] != 'AM' && $_POST['meridiem'] != 'PM'))
+                $hour   = $_POST['hour'];
+                $minute = $_POST['minute'];
+
+                if ($_SESSION['CATS']->isTimeFormat24())
                 {
-                    CommonErrors::fatalModal(COMMONERROR_MISSINGFIELDS, $this, 'Invalid meridiem value.');
+                    $time = strtotime(sprintf('%02d:%02d', $hour, $minute));
                 }
+                else
+                {
+                    /* Bail out if we don't have a valid meridiem value. */
+                    if (!isset($_POST['meridiem']) ||
+                        ($_POST['meridiem'] != 'AM' && $_POST['meridiem'] != 'PM'))
+                    {
+                        CommonErrors::fatalModal(COMMONERROR_MISSINGFIELDS, $this, 'Invalid meridiem value.');
+                    }
 
-                $hour     = $_POST['hour'];
-                $minute   = $_POST['minute'];
-                $meridiem = $_POST['meridiem'];
+                    $meridiem = $_POST['meridiem'];
 
-                /* Convert formatted time to UNIX timestamp. */
-                $time = strtotime(
-                    sprintf('%s:%s %s', $hour, $minute, $meridiem)
-                );
+                    /* Convert formatted time to UNIX timestamp. */
+                    $time = strtotime(
+                        sprintf('%s:%s %s', $hour, $minute, $meridiem)
+                    );
+                }
 
                 /* Create MySQL date string w/ 24hr time (YYYY-MM-DD HH:MM:SS). */
                 $date = sprintf(

--- a/modules/contacts/Show.tpl
+++ b/modules/contacts/Show.tpl
@@ -7,7 +7,8 @@ use OpenCATS\UI\QuickActionMenu;
 <?php TemplateUtility::printHeaderBlock(); ?>
 <?php TemplateUtility::printTabs($this->active); ?>
     <script type="text/javascript">
-        window.CATSUserDateFormat = <?php echo Template::escapeJs($_SESSION['CATS']->isDateDMY() ? 'DD-MM-YY' : 'MM-DD-YY'); ?>;
+        window.CATSUserDateFormat  = <?php echo Template::escapeJs($_SESSION['CATS']->isDateDMY() ? 'DD-MM-YY' : 'MM-DD-YY'); ?>;
+        window.CATSTimeFormat24    = <?php echo $_SESSION['CATS']->isTimeFormat24() ? 'true' : 'false'; ?>;
     </script>
     <div id="main">
         <?php TemplateUtility::printQuickSearch(); ?>

--- a/modules/home/dataGrids.php
+++ b/modules/home/dataGrids.php
@@ -72,6 +72,9 @@ class ImportantPipelineDashboard extends DataGrid
         $this->_assignedCriterion = "";
         $this->_candidateIDColumn = 'company.company_id';
 
+        $rawTimeFormat = (isset($_SESSION['CATS']) && $_SESSION['CATS']->isTimeFormat24())
+            ? '%H:%i' : '%h:%i %p';
+
         $this->_classColumns = array(
 
             'First Name' =>     array('pagerRender'    => '$ret = \'<img src="images/mru/candidate.gif" height="12" alt="" />\'; if ($rsData[\'isHot\'] == 1) $className =  \'jobLinkHot\'; else $className = \'jobLinkCold\'; return $ret.\'&nbsp;<a href="'.CATSUtility::getIndexName().'?m=candidates&amp;a=show&amp;candidateID=\'.$rsData[\'candidateID\'].\'" style="font-size:11px;" class="\'.$className.\'" title="\'.htmlspecialchars(InfoString::make(DATA_ITEM_CANDIDATE,$rsData[\'candidateID\'])).\'">\'.htmlspecialchars($rsData[\'firstName\']).\'</a>\';',
@@ -110,7 +113,7 @@ class ImportantPipelineDashboard extends DataGrid
                                      'sortableColumn'  => 'dateModifiedSort',
                                      'pagerWidth'      => 70,
                                      'pagerOptional'   => true,
-                                     'filterHaving'    => 'DATE_FORMAT(candidate_joborder.date_modified, \'%m-%d-%y (%%h:%%i %%p)\')'),
+                                     'filterHaving'    => 'DATE_FORMAT(candidate_joborder.date_modified, \'%m-%d-%y (' . $rawTimeFormat . ')\')'),
          );
 
         parent::__construct("home:ImportantPipelineDashboard", $parameters);
@@ -315,7 +318,7 @@ class CallsDataGrid extends DataGrid
                 activity.notes AS notes,
                 activity_type.short_description AS typeDescription,
                 DATE_FORMAT(
-                    activity.date_occurred, '%%m-%%d-%%y %%h:%%i %%p'
+                    activity.date_occurred, '" . (isset($_SESSION['CATS']) && $_SESSION['CATS']->isTimeFormat24() ? '%%m-%%d-%%y %%H:%%i' : '%%m-%%d-%%y %%h:%%i %%p') . "'
                 ) AS dateCreated,
                 activity.date_occurred AS dateCreatedSort,
                 entered_by_user.first_name AS enteredByFirstName,
@@ -366,7 +369,7 @@ class CallsDataGrid extends DataGrid
                 activity.notes AS notes,
                 activity_type.short_description AS typeDescription,
                 DATE_FORMAT(
-                    activity.date_occurred, '%%m-%%d-%%y %%h:%%i %%p'
+                    activity.date_occurred, '" . (isset($_SESSION['CATS']) && $_SESSION['CATS']->isTimeFormat24() ? '%%m-%%d-%%y %%H:%%i' : '%%m-%%d-%%y %%h:%%i %%p') . "'
                 ) AS dateCreated,
                 activity.date_occurred AS dateCreatedSort,
                 entered_by_user.first_name AS enteredByFirstName,

--- a/modules/import/Import.php
+++ b/modules/import/Import.php
@@ -163,7 +163,7 @@ class Import
                 import.added_lines AS addedLines,
                 import.import_errors AS importErrors,
 				DATE_FORMAT(
-                    import.date_created, '%%m-%%d-%%y (%%h:%%i %%p)'
+                    import.date_created, '" . DateUtility::getMysqlDateTimeFormat() . "'
                 ) AS dateCreated
             FROM
                 import

--- a/modules/install/ajax/ui.php
+++ b/modules/install/ajax/ui.php
@@ -518,6 +518,7 @@ switch ($action)
         }
         $onClick .= '&timeZone=\' + encodeURIComponent(document.getElementById(\'timeZone\').value) + \'';
         $onClick .= '&dateFormat=\' + encodeURIComponent(document.getElementById(\'dateFormat\').value) + \'';
+        $onClick .= '&timeFormat=\' + encodeURIComponent(document.getElementById(\'timeFormat\').value) + \'';
         $onClick .= '&defaultPhoneCountryCodeDigits=\' + encodeURIComponent(document.getElementById(\'defaultPhoneCountryCodeDigits\').value));';
 
         echo '<script type="text/javascript">';
@@ -549,9 +550,11 @@ switch ($action)
         CATSUtility::changeConfigSetting('OFFSET_GMT', ($timeZone));
 
         $dateFormat = $_REQUEST['dateFormat'];
+        $timeFormat = isset($_REQUEST['timeFormat']) ? $_REQUEST['timeFormat'] : '12';
 
         $_SESSION['timeZoneInstaller'] = $timeZone;
         $_SESSION['dateFormatInstaller'] = $dateFormat;
+        $_SESSION['timeFormatInstaller'] = $timeFormat;
 
         // Default phone country calling code collected in the installer.
         if (isset($_REQUEST['defaultPhoneCountryCodeDigits']))
@@ -965,6 +968,9 @@ switch ($action)
         {
             MySQLQuery('UPDATE site SET date_format_ddmmyy = 1');
         }
+
+        $timeFormat = isset($_SESSION['timeFormatInstaller']) ? $_SESSION['timeFormatInstaller'] : '12';
+        MySQLQuery('UPDATE site SET time_format_24 = ' . ($timeFormat === '24' ? 1 : 0));
 
         $timeZone = $_SESSION['timeZoneInstaller'];
 

--- a/modules/login/wizard/Localization.tpl
+++ b/modules/login/wizard/Localization.tpl
@@ -16,6 +16,16 @@
             </select>
         </td>
     </tr>
+
+    <tr>
+        <td style="font-size: 14px;">Time Format</td>
+        <td style="font-size: 14px; padding-bottom: 5px;">
+            <select id="timeFormat" name="timeFormat" style="width: 150px;">
+                <option value="12"<?php if (!$this->isTimeFormat24): ?> selected<?php endif; ?>>12-hour (1:30 PM)</option>
+                <option value="24"<?php if ($this->isTimeFormat24): ?> selected<?php endif; ?>>24-hour (13:30)</option>
+            </select>
+        </td>
+    </tr>
 </table>
 <p />
 These settings will effect how you see dates and times in OpenCATS.

--- a/modules/settings/CustomizeCalendar.tpl
+++ b/modules/settings/CustomizeCalendar.tpl
@@ -51,32 +51,16 @@
                                         Work day start time:
                                     </td>
                                     <td class="tdData">
-                                        <?php // FIXME: Generate this more automatically? ?>
                                         <select name="dayStart">
-                                            <option value="1"<?php if ($this->calendarSettingsRS['dayStart'] == '1'): ?> selected<?php endif; ?>>1 AM</option>
-                                            <option value="2"<?php if ($this->calendarSettingsRS['dayStart'] == '2'): ?> selected<?php endif; ?>>2 AM</option>
-                                            <option value="3"<?php if ($this->calendarSettingsRS['dayStart'] == '3'): ?> selected<?php endif; ?>>3 AM</option>
-                                            <option value="4"<?php if ($this->calendarSettingsRS['dayStart'] == '4'): ?> selected<?php endif; ?>>4 AM</option>
-                                            <option value="5"<?php if ($this->calendarSettingsRS['dayStart'] == '5'): ?> selected<?php endif; ?>>5 AM</option>
-                                            <option value="6"<?php if ($this->calendarSettingsRS['dayStart'] == '6'): ?> selected<?php endif; ?>>6 AM</option>
-                                            <option value="7"<?php if ($this->calendarSettingsRS['dayStart'] == '7'): ?> selected<?php endif; ?>>7 AM</option>
-                                            <option value="8"<?php if ($this->calendarSettingsRS['dayStart'] == '8'): ?> selected<?php endif; ?>>8 AM</option>
-                                            <option value="9"<?php if ($this->calendarSettingsRS['dayStart'] == '9'): ?> selected<?php endif; ?>>9 AM</option>
-                                            <option value="10"<?php if ($this->calendarSettingsRS['dayStart'] == '10'): ?> selected<?php endif; ?>>10 AM</option>
-                                            <option value="11"<?php if ($this->calendarSettingsRS['dayStart'] == '11'): ?> selected<?php endif; ?>>11 AM</option>
-                                            <option value="12"<?php if ($this->calendarSettingsRS['dayStart'] == '12'): ?> selected<?php endif; ?>>12 PM</option>
-                                            <option value="13"<?php if ($this->calendarSettingsRS['dayStart'] == '13'): ?> selected<?php endif; ?>>1 PM</option>
-                                            <option value="14"<?php if ($this->calendarSettingsRS['dayStart'] == '14'): ?> selected<?php endif; ?>>2 PM</option>
-                                            <option value="15"<?php if ($this->calendarSettingsRS['dayStart'] == '15'): ?> selected<?php endif; ?>>3 PM</option>
-                                            <option value="16"<?php if ($this->calendarSettingsRS['dayStart'] == '16'): ?> selected<?php endif; ?>>4 PM</option>
-                                            <option value="17"<?php if ($this->calendarSettingsRS['dayStart'] == '17'): ?> selected<?php endif; ?>>5 PM</option>
-                                            <option value="18"<?php if ($this->calendarSettingsRS['dayStart'] == '18'): ?> selected<?php endif; ?>>6 PM</option>
-                                            <option value="19"<?php if ($this->calendarSettingsRS['dayStart'] == '19'): ?> selected<?php endif; ?>>7 PM</option>
-                                            <option value="20"<?php if ($this->calendarSettingsRS['dayStart'] == '20'): ?> selected<?php endif; ?>>8 PM</option>
-                                            <option value="21"<?php if ($this->calendarSettingsRS['dayStart'] == '21'): ?> selected<?php endif; ?>>9 PM</option>
-                                            <option value="22"<?php if ($this->calendarSettingsRS['dayStart'] == '22'): ?> selected<?php endif; ?>>10 PM</option>
-                                            <option value="23"<?php if ($this->calendarSettingsRS['dayStart'] == '23'): ?> selected<?php endif; ?>>11 PM</option>
-                                            <option value="0"<?php if ($this->calendarSettingsRS['dayStart'] == '0'): ?> selected<?php endif; ?>>12 AM</option>
+                                            <?php foreach ($this->isTimeFormat24 ? range(0, 23) : array_merge(range(1, 23), array(0)) as $_h): ?>
+                                            <option value="<?php echo $_h; ?>"<?php if ($this->calendarSettingsRS['dayStart'] == $_h): ?> selected<?php endif; ?>><?php
+                                                if ($this->isTimeFormat24) { echo sprintf('%02d:00', $_h); }
+                                                elseif ($_h == 0)  { echo '12 AM'; }
+                                                elseif ($_h < 12)  { echo $_h . ' AM'; }
+                                                elseif ($_h == 12) { echo '12 PM'; }
+                                                else               { echo ($_h - 12) . ' PM'; }
+                                            ?></option>
+                                            <?php endforeach; ?>
                                         </select>
                                     </td>
                                 </tr>
@@ -85,32 +69,16 @@
                                         Work day stop time:
                                     </td>
                                     <td class="tdData">
-                                        <?php // FIXME: Generate this more automatically? ?>
                                         <select name="dayStop">
-                                            <option value="1"<?php if ($this->calendarSettingsRS['dayStop'] == '1'): ?> selected<?php endif; ?>>1 AM</option>
-                                            <option value="2"<?php if ($this->calendarSettingsRS['dayStop'] == '2'): ?> selected<?php endif; ?>>2 AM</option>
-                                            <option value="3"<?php if ($this->calendarSettingsRS['dayStop'] == '3'): ?> selected<?php endif; ?>>3 AM</option>
-                                            <option value="4"<?php if ($this->calendarSettingsRS['dayStop'] == '4'): ?> selected<?php endif; ?>>4 AM</option>
-                                            <option value="5"<?php if ($this->calendarSettingsRS['dayStop'] == '5'): ?> selected<?php endif; ?>>5 AM</option>
-                                            <option value="6"<?php if ($this->calendarSettingsRS['dayStop'] == '6'): ?> selected<?php endif; ?>>6 AM</option>
-                                            <option value="7"<?php if ($this->calendarSettingsRS['dayStop'] == '7'): ?> selected<?php endif; ?>>7 AM</option>
-                                            <option value="8"<?php if ($this->calendarSettingsRS['dayStop'] == '8'): ?> selected<?php endif; ?>>8 AM</option>
-                                            <option value="9"<?php if ($this->calendarSettingsRS['dayStop'] == '9'): ?> selected<?php endif; ?>>9 AM</option>
-                                            <option value="10"<?php if ($this->calendarSettingsRS['dayStop'] == '10'): ?> selected<?php endif; ?>>10 AM</option>
-                                            <option value="11"<?php if ($this->calendarSettingsRS['dayStop'] == '11'): ?> selected<?php endif; ?>>11 AM</option>
-                                            <option value="12"<?php if ($this->calendarSettingsRS['dayStop'] == '12'): ?> selected<?php endif; ?>>12 PM</option>
-                                            <option value="13"<?php if ($this->calendarSettingsRS['dayStop'] == '13'): ?> selected<?php endif; ?>>1 PM</option>
-                                            <option value="14"<?php if ($this->calendarSettingsRS['dayStop'] == '14'): ?> selected<?php endif; ?>>2 PM</option>
-                                            <option value="15"<?php if ($this->calendarSettingsRS['dayStop'] == '15'): ?> selected<?php endif; ?>>3 PM</option>
-                                            <option value="16"<?php if ($this->calendarSettingsRS['dayStop'] == '16'): ?> selected<?php endif; ?>>4 PM</option>
-                                            <option value="17"<?php if ($this->calendarSettingsRS['dayStop'] == '17'): ?> selected<?php endif; ?>>5 PM</option>
-                                            <option value="18"<?php if ($this->calendarSettingsRS['dayStop'] == '18'): ?> selected<?php endif; ?>>6 PM</option>
-                                            <option value="19"<?php if ($this->calendarSettingsRS['dayStop'] == '19'): ?> selected<?php endif; ?>>7 PM</option>
-                                            <option value="20"<?php if ($this->calendarSettingsRS['dayStop'] == '20'): ?> selected<?php endif; ?>>8 PM</option>
-                                            <option value="21"<?php if ($this->calendarSettingsRS['dayStop'] == '21'): ?> selected<?php endif; ?>>9 PM</option>
-                                            <option value="22"<?php if ($this->calendarSettingsRS['dayStop'] == '22'): ?> selected<?php endif; ?>>10 PM</option>
-                                            <option value="23"<?php if ($this->calendarSettingsRS['dayStop'] == '23'): ?> selected<?php endif; ?>>11 PM</option>
-                                            <option value="0"<?php if ($this->calendarSettingsRS['dayStop'] == '0'): ?> selected<?php endif; ?>>12 AM</option>
+                                            <?php foreach ($this->isTimeFormat24 ? range(0, 23) : array_merge(range(1, 23), array(0)) as $_h): ?>
+                                            <option value="<?php echo $_h; ?>"<?php if ($this->calendarSettingsRS['dayStop'] == $_h): ?> selected<?php endif; ?>><?php
+                                                if ($this->isTimeFormat24) { echo sprintf('%02d:00', $_h); }
+                                                elseif ($_h == 0)  { echo '12 AM'; }
+                                                elseif ($_h < 12)  { echo $_h . ' AM'; }
+                                                elseif ($_h == 12) { echo '12 PM'; }
+                                                else               { echo ($_h - 12) . ' PM'; }
+                                            ?></option>
+                                            <?php endforeach; ?>
                                         </select>
                                     </td>
                                 </tr>

--- a/modules/settings/Localization.tpl
+++ b/modules/settings/Localization.tpl
@@ -47,6 +47,18 @@
                                 </tr>
 
                                 <tr>
+                                    <td>Please choose your preferred time format.</td>
+                                </tr>
+                                <tr>
+                                    <td style="padding-bottom: 5px;">
+                                        <select id="timeFormat" name="timeFormat" style="width: 150px;">
+                                            <option value="12"<?php if (!$this->isTimeFormat24): ?> selected<?php endif; ?>>12-hour (1:30 PM)</option>
+                                            <option value="24"<?php if ($this->isTimeFormat24): ?> selected<?php endif; ?>>24-hour (13:30)</option>
+                                        </select>
+                                    </td>
+                                </tr>
+
+                                <tr>
                                     <td>Please enter your default phone country calling code.</td>
                                 </tr>
                                 <tr>

--- a/modules/settings/NewInstallWizard.tpl
+++ b/modules/settings/NewInstallWizard.tpl
@@ -80,6 +80,18 @@
                                     </select>
                                 </td>
                             </tr>
+
+                            <tr>
+                                <td>Please choose your preferred time format.</td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <select id="timeFormat" name="timeFormat" style="width: 150px;">
+                                        <option value="12" selected="selected">12-hour (1:30 PM)</option>
+                                        <option value="24">24-hour (13:30)</option>
+                                    </select>
+                                </td>
+                            </tr>
                         </table>
                         <br />
 

--- a/modules/settings/SettingsUI.php
+++ b/modules/settings/SettingsUI.php
@@ -2052,6 +2052,7 @@ class SettingsUI extends UserInterface
         $calendarSettingsRS = $calendarSettings->getAll();
 
         $this->_template->assign('calendarSettingsRS', $calendarSettingsRS);
+        $this->_template->assign('isTimeFormat24', $_SESSION['CATS']->isTimeFormat24());
         $this->_template->assign('active', $this);
         $this->_template->assign('subActive', 'Administration');
         $this->_template->display('./modules/settings/CustomizeCalendar.tpl');
@@ -2398,6 +2399,7 @@ class SettingsUI extends UserInterface
 
                     $this->_template->assign('timeZone', $_SESSION['CATS']->getTimeZone());
                     $this->_template->assign('isDateDMY', $_SESSION['CATS']->isDateDMY());
+                    $this->_template->assign('isTimeFormat24', $_SESSION['CATS']->isTimeFormat24());
 
                     // Default phone country calling code for the localization settings page.
                     $defaultPhoneCountryCode = $_SESSION['CATS']->getDefaultPhoneCountryCode();
@@ -2556,8 +2558,10 @@ class SettingsUI extends UserInterface
                     $isDMY = true;
                 }
 
+                $isTimeFormat24 = (isset($_POST['timeFormat']) && $_POST['timeFormat'] === '24');
+
                 $site = new Site();
-                $site->setLocalization($timeZone, $isDMY);
+                $site->setLocalization($timeZone, $isDMY, $isTimeFormat24);
 
                 // Default phone country calling code (E.164) for the site.
                 if (isset($_POST['defaultPhoneCountryCodeDigits']))
@@ -2610,11 +2614,13 @@ class SettingsUI extends UserInterface
             $isDMY = true;
         }
 
+        $isTimeFormat24 = (isset($_POST['timeFormat']) && $_POST['timeFormat'] === '24');
+
         $site = new Site();
-        $site->setLocalization($timeZone, $dateFormat);
+        $site->setLocalization($timeZone, $isDMY, $isTimeFormat24);
 
         /* Reload the new data for the session. */
-        $_SESSION['CATS']->setTimeDateLocalization($timeZone, $isDMY);
+        $_SESSION['CATS']->setTimeDateLocalization($timeZone, $isDMY, $isTimeFormat24);
 
         $this->_template->assign('inputType', 'conclusion');
         $this->_template->assign('title', 'Localization Settings Saved!');

--- a/modules/settings/SettingsUI.php
+++ b/modules/settings/SettingsUI.php
@@ -3036,8 +3036,10 @@ class SettingsUI extends UserInterface
             $isDMY = true;
         }
 
+        $isTimeFormat24 = (isset($_GET['timeFormat']) && $_GET['timeFormat'] === '24');
+
         $site = new Site();
-        $site->setLocalization($timeZone, $isDMY);
+        $site->setLocalization($timeZone, $isDMY, $isTimeFormat24);
         $site->setLocalizationConfigured();
 
         echo 'Ok';

--- a/modules/wizard/WizardUI.php
+++ b/modules/wizard/WizardUI.php
@@ -66,6 +66,7 @@ class WizardUI extends UserInterface
         $this->addPage('Localization', './modules/wizard/WizardIntroLocalization.tpl', '
             $this->_template->assign(\'timeZone\', $_SESSION[\'CATS\']->getTimeZone());
             $this->_template->assign(\'isDateDMY\', $_SESSION[\'CATS\']->isDateDMY());
+            $this->_template->assign(\'isTimeFormat24\', $_SESSION[\'CATS\']->isTimeFormat24());
         ');
 
         $this->addJsInclude('./js/wizardIntro.js');

--- a/src/OpenCATS/Tests/IntegrationTests/EntityDeleteCleanupTest.php
+++ b/src/OpenCATS/Tests/IntegrationTests/EntityDeleteCleanupTest.php
@@ -42,6 +42,11 @@ class EntityDeleteCleanupTest extends DatabaseTestCase
             {
                 return false;
             }
+
+            public function isTimeFormat24()
+            {
+                return false;
+            }
         };
 
         include_once(LEGACY_ROOT . '/lib/CATSUtility.php');

--- a/src/OpenCATS/Tests/UnitTests/DateUtilityTest.php
+++ b/src/OpenCATS/Tests/UnitTests/DateUtilityTest.php
@@ -225,6 +225,71 @@ class DateUtilityTest extends TestCase
                 );
         }
     }
+
+    /* Tests for getMysqlTimeFormat(). */
+    function testGetMysqlTimeFormat()
+    {
+        $this->assertSame('%%h:%%i %%p', DateUtility::getMysqlTimeFormat(false));
+        $this->assertSame('%%H:%%i',     DateUtility::getMysqlTimeFormat(true));
+    }
+
+    /* Tests for getMysqlDateTimeFormat(). */
+    function testGetMysqlDateTimeFormat()
+    {
+        $this->assertSame('%%m-%%d-%%y (%%h:%%i %%p)', DateUtility::getMysqlDateTimeFormat(false));
+        $this->assertSame('%%m-%%d-%%y (%%H:%%i)',     DateUtility::getMysqlDateTimeFormat(true));
+    }
+
+    /* Tests for getMysqlDateTimeSecondsFormat(). */
+    function testGetMysqlDateTimeSecondsFormat()
+    {
+        $this->assertSame('%%m-%%d-%%y (%%h:%%i:%%s %%p)', DateUtility::getMysqlDateTimeSecondsFormat(false));
+        $this->assertSame('%%m-%%d-%%y (%%H:%%i:%%s)',     DateUtility::getMysqlDateTimeSecondsFormat(true));
+    }
+
+    /* Tests for getTimeFormat(). */
+    function testGetTimeFormat()
+    {
+        $this->assertSame('g:i A', DateUtility::getTimeFormat(false));
+        $this->assertSame('H:i',   DateUtility::getTimeFormat(true));
+    }
+
+    /* Tests for getDateTimeFormat(). */
+    function testGetDateTimeFormat()
+    {
+        $this->assertSame('m-d-Y g:i A', DateUtility::getDateTimeFormat('m-d-Y', false));
+        $this->assertSame('m-d-Y H:i',   DateUtility::getDateTimeFormat('m-d-Y', true));
+        $this->assertSame('d-m-Y g:i A', DateUtility::getDateTimeFormat('d-m-Y', false));
+        $this->assertSame('d-m-Y H:i',   DateUtility::getDateTimeFormat('d-m-Y', true));
+    }
+
+    /* Tests for normalizeActivityTime(). */
+    function testNormalizeActivityTime()
+    {
+        /* 12-hour mode standard cases. */
+        $this->assertSame('01:30:00', DateUtility::normalizeActivityTime(1,  30, 'AM', false));
+        $this->assertSame('13:30:00', DateUtility::normalizeActivityTime(1,  30, 'PM', false));
+        $this->assertSame('11:59:00', DateUtility::normalizeActivityTime(11, 59, 'AM', false));
+        $this->assertSame('23:59:00', DateUtility::normalizeActivityTime(11, 59, 'PM', false));
+
+        /* Midnight: 12:00 AM must become 00:00:00. */
+        $this->assertSame('00:00:00', DateUtility::normalizeActivityTime(12, 0, 'AM', false));
+
+        /* Noon: 12:00 PM must become 12:00:00. */
+        $this->assertSame('12:00:00', DateUtility::normalizeActivityTime(12, 0, 'PM', false));
+
+        /* 24-hour mode stored directly. */
+        $this->assertSame('00:00:00', DateUtility::normalizeActivityTime(0,  0,  '', true));
+        $this->assertSame('13:30:00', DateUtility::normalizeActivityTime(13, 30, '', true));
+        $this->assertSame('23:59:00', DateUtility::normalizeActivityTime(23, 59, '', true));
+
+        /* Invalid inputs must return false. */
+        $this->assertFalse(DateUtility::normalizeActivityTime(0,  0,  'AM', false)); /* hour 0 invalid in 12h */
+        $this->assertFalse(DateUtility::normalizeActivityTime(13, 0,  'AM', false)); /* hour 13 invalid in 12h */
+        $this->assertFalse(DateUtility::normalizeActivityTime(24, 0,  '',   true));  /* hour 24 invalid in 24h */
+        $this->assertFalse(DateUtility::normalizeActivityTime(1,  60, 'AM', false)); /* minute 60 invalid */
+        $this->assertFalse(DateUtility::normalizeActivityTime(1,  0,  '',   false)); /* missing meridiem in 12h */
+    }
 }
 
 ?>


### PR DESCRIPTION
## Summary

This PR adds a configurable site-wide time format setting that allows OpenCATS installations to use either 12-hour or 24-hour time display.

This wires the existing `site.time_format_24` setting into site localization, session handling, localization settings, the first-run wizard and the installer. It also applies the configured time format across activity display and editing, calendar forms and settings, email template date/time replacement and other user-facing date/time output where appropriate.

The default behavior remains unchanged: existing installations continue to use the 12-hour format unless the 24-hour format is explicitly selected.

## Motivation

This improves OpenCATS internationalization by allowing installations to use the time format that matches their locale and users' expectations.

A large share of countries commonly use the 24-hour time format. Supporting both 12-hour and 24-hour formats makes OpenCATS more suitable for international deployments while preserving the existing default behavior for users who prefer the 12-hour format.