### PR TITLE
chore: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Adds a GitHub Actions workflow that enables GitHub auto-merge for eligible Dependabot pull requests.

The workflow runs for Dependabot pull requests only, reads Dependabot metadata and enables auto-merge with squash merge for patch and minor dependency updates. Semver-major updates are intentionally excluded so they still require manual review.

This workflow only enables GitHub auto-merge and does not bypass branch protection or required checks. The repository must have Allow auto-merge enabled and the target branch should have the required status checks configured so Dependabot pull requests are merged only after those checks pass.