### PR TITLE
chore: prepare CI for PHP version matrix testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php-version }}-
+            ${{ runner.os }}-php-
 
       - name: Install Dependencies
         run: composer install --no-progress --prefer-dist
@@ -61,7 +63,7 @@ jobs:
           touch ./INSTALL_BLOCK
 
           cd docker/
-          docker compose -f docker-compose-test.yml up -d
+          PHP_VERSION=${{ matrix.php-version }} docker compose -f docker-compose-test.yml up -d --build
 
           echo "Waiting for BOTH databases..."
           opencatsdb_container="$(docker compose -f docker-compose-test.yml ps -q opencatsdb)"

--- a/docker/docker-compose-test.yml
+++ b/docker/docker-compose-test.yml
@@ -13,6 +13,8 @@ services:
       build:
         context: ..
         dockerfile: docker/php/Dockerfile
+        args:
+          PHP_VERSION: ${PHP_VERSION:-7.4}
       working_dir: /var/www/public
       volumes_from:
         - opencatsdata

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.4-fpm-alpine
+ARG PHP_VERSION=7.4
+FROM php:${PHP_VERSION}-fpm-alpine
 
 # Runtime/system packages required by OpenCATS and helper tools.
 RUN apk add --no-cache \


### PR DESCRIPTION
This prepares the CI and Docker-based test setup for PHP version matrix testing, serving as preparation for #792 without changing the currently tested or supported PHP version.

The Docker PHP image now accepts a `PHP_VERSION` build argument while keeping `7.4` as the default. The test Docker Compose configuration passes this argument through with the same default, so existing local and CI behavior remains unchanged unless a PHP version is explicitly provided.

The GitHub Actions workflow now passes the matrix PHP version into the Docker test environment and rebuilds the container for that version. Composer cache keys also include the matrix PHP version, so future matrix entries can use separate dependency caches.