### PR TITLE
feat: add country-aware OpenStreetMap ZIP lookup

### DIFF
--- a/ajax/zipLookup.php
+++ b/ajax/zipLookup.php
@@ -17,12 +17,13 @@ if (!isset($_REQUEST['zip']))
 }
 
 $zip = $_REQUEST['zip'];
+$country = isset($_REQUEST['country']) ? $_REQUEST['country'] : '';
 
 $zipLookup = new ZipLookup();
 
 $searchableZip = $zipLookup->makeSearchableUSZip($zip);
 
-$data = $zipLookup->getCityStateByZip($searchableZip);
+$data = $zipLookup->getCityStateByZip($searchableZip, $country);
 
 $street = $data[1];
 $city  = $data[2];

--- a/js/lib.js
+++ b/js/lib.js
@@ -526,8 +526,15 @@ function CityState_populate(zipEditID, indicatorID)
 
     indicator.style.visibility = "visible";
 
-     /* Build HTTP POST data. */
+     /* Build HTTP POST data. Include the country so postal-code lookups are
+      * scoped to the right one (postal codes are not globally unique). */
     var POSTData = "&zip=" + urlEncode(zip);
+
+    var countryElement = document.getElementById("country");
+    if (countryElement)
+    {
+        POSTData += "&country=" + urlEncode(countryElement.value);
+    }
 
     /* Anonymous callback function triggered when HTTP response is received. */
     var callBack = function ()

--- a/js/lib.js
+++ b/js/lib.js
@@ -578,40 +578,21 @@ function CityState_populate(zipEditID, indicatorID)
         var cityNode  = http.responseXML.getElementsByTagName("city").item(0);
         var stateNode = http.responseXML.getElementsByTagName("state").item(0);
 
-	if (document.getElementById("address"))
+        /* Only fill fields the lookup actually resolved; leave anything the
+         * user already typed (e.g. a street the zip lookup can't return). */
+        if (document.getElementById("address") && addressNode.firstChild)
         {
-            if (addressNode.firstChild)
-            {
-                document.getElementById("address").value = addressNode.firstChild.nodeValue;
-            }
-            else
-            {
-                document.getElementById("address").value = "";
-            }
+            document.getElementById("address").value = addressNode.firstChild.nodeValue;
         }
 
-        if (document.getElementById("city"))
+        if (document.getElementById("city") && cityNode.firstChild)
         {
-            if (cityNode.firstChild)
-            {
-                document.getElementById("city").value = cityNode.firstChild.nodeValue;
-            }
-            else
-            {
-                document.getElementById("city").value = "";
-            }
+            document.getElementById("city").value = cityNode.firstChild.nodeValue;
         }
 
-        if (document.getElementById("state"))
+        if (document.getElementById("state") && stateNode.firstChild)
         {
-            if (stateNode.firstChild)
-            {
-                document.getElementById("state").value = stateNode.firstChild.nodeValue;
-            }
-            else
-            {
-                document.getElementById("state").value = "";
-            }
+            document.getElementById("state").value = stateNode.firstChild.nodeValue;
         }
         indicator.style.visibility = "hidden";
     }

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -1,10 +1,9 @@
 <?php
 /**
-* Google API Zip Code Lookup library
+* OpenStreetMap (Nominatim) Zip Code Lookup library
 */
 class ZipLookup
 {
-
      public static function makeSearchableUSZip($zipString)
      {
 
@@ -20,45 +19,58 @@ class ZipLookup
 	$aAddress[2] = '';
 	$aAddress[3] = '';
 
-	$sUrl = 'http://maps.googleapis.com/maps/api/geocode/xml?sensor=false&address=';
-
-	if ($zip != '') {
-		if (($oXml = simplexml_load_file($sUrl . $zip))) {
-			foreach($oXml->result->address_component as $value) {
-				if ($value->type == 'route') {
-					$aAddress[1] = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'postal_town') {
-					$loc_level_1 = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'locality') {
-					$loc_level_1 = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'administrative_area_level_1') {
-					$loc_level_2 = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'administrative_area_level_2') {
-					$loc_level_3 = (string) $value->long_name;
-				}
-				if ($value->type[0] == 'country') {
-					$loc_level_4 = (string) $value->short_name;
-				}
-			}
-		} else {
-			$aAddress[0] = 1;
-		}
-	} else {
+	if ($zip == '') {
 		$aAddress[0] = 2;
+		return $aAddress;
 	}
 
-	// Set the state based on US or non-US location
-	$aAddress[2] = $loc_level_1;
-	if ($loc_level_4 == 'US') {
-		$aAddress[3] = $loc_level_3;
-	} else {
-		$aAddress[3] = $loc_level_2;
+	$sUrl = 'https://nominatim.openstreetmap.org/search?format=jsonv2'
+	      . '&addressdetails=1&limit=1&postalcode='
+	      . rawurlencode($zip);
+
+	/* Nominatim's usage policy requires a User-Agent that identifies the
+	 * calling application; use the site's host so each install is distinct. */
+	$sHost = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'unknown-host';
+	$context = stream_context_create(array(
+		'http' => array(
+			'method'  => 'GET',
+			'header'  => 'User-Agent: OpenCATS-ZipLookup (' . $sHost . ")\r\n",
+			'timeout' => 10,
+		),
+	));
+
+	$sResponse = @file_get_contents($sUrl, false, $context);
+	if ($sResponse === false) {
+		$aAddress[0] = 1;
+		return $aAddress;
 	}
-	    
+
+	$aResults = json_decode($sResponse, true);
+	if (!is_array($aResults) || empty($aResults) || empty($aResults[0]['address'])) {
+		$aAddress[0] = 1;
+		return $aAddress;
+	}
+
+	$aParts = $aResults[0]['address'];
+
+	if (isset($aParts['road'])) {
+		$aAddress[1] = (string) $aParts['road'];
+	}
+
+	// Nominatim spreads the locality across several keys depending on place size.
+	foreach (array('city', 'town', 'village', 'hamlet', 'municipality') as $sKey) {
+		if (isset($aParts[$sKey])) {
+			$aAddress[2] = (string) $aParts[$sKey];
+			break;
+		}
+	}
+
+	if (isset($aParts['state'])) {
+		$aAddress[3] = (string) $aParts['state'];
+	} else if (isset($aParts['county'])) {
+		$aAddress[3] = (string) $aParts['county'];
+	}
+
 	return $aAddress;
 
     }

--- a/lib/ZipLookup.php
+++ b/lib/ZipLookup.php
@@ -10,7 +10,7 @@ class ZipLookup
 	return str_replace(' ', '', $zipString);
      }
 
-    public function getCityStateByZip($zip)
+    public function getCityStateByZip($zip, $country = '')
     {
 
 
@@ -27,6 +27,14 @@ class ZipLookup
 	$sUrl = 'https://nominatim.openstreetmap.org/search?format=jsonv2'
 	      . '&addressdetails=1&limit=1&postalcode='
 	      . rawurlencode($zip);
+
+	/* Postal codes are not globally unique, so without a country the first
+	 * match can land in the wrong one. Scope by the ISO country code when the
+	 * form supplies it. */
+	$sCountry = strtolower(preg_replace('/[^A-Za-z]/', '', $country));
+	if (strlen($sCountry) == 2) {
+		$sUrl .= '&countrycodes=' . $sCountry;
+	}
 
 	/* Nominatim's usage policy requires a User-Agent that identifies the
 	 * calling application; use the site's host so each install is distinct. */


### PR DESCRIPTION
## Summary

Replaces the ZIP code lookup implementation with OpenStreetMap Nominatim instead of the previous Google Maps Geocoding XML endpoint.

The lookup now uses Nominatim’s JSON API, sends an identifying `User-Agent`, scopes postal-code searches by the selected country when available and maps returned address fields back into the existing street, city and state response structure used by the current AJAX ZIP lookup flow.

The frontend now includes the selected country in ZIP lookup requests and only updates address fields when the lookup actually returns values, preserving user-entered data when Nominatim does not return a matching street, city, or state.

## Motivation

The existing ZIP lookup depended on the legacy Google Maps Geocoding endpoint. Google now requires API keys for Maps Platform geocoding requests, which makes the old unauthenticated lookup path unsuitable for the current OpenCATS setup.

Moving this lookup to OpenStreetMap Nominatim removes that dependency while keeping the existing OpenCATS ZIP lookup flow intact.

Postal codes are not globally unique, so passing the selected country helps avoid incorrect matches from other countries. Preserving existing field values when no lookup result is returned also prevents the ZIP lookup from accidentally clearing information the user already entered manually.

This keeps the change focused on the existing ZIP lookup path while improving provider independence, lookup accuracy and user experience.