### PR TITLE
fix: prevent fatal error when mail is not configured in Career Portal

### DIFF
--- a/lib/CareerPortal.php
+++ b/lib/CareerPortal.php
@@ -423,13 +423,24 @@ class CareerPortalSettings
 
         /* Send e-mail notification. */
         //FIXME: Make subject configurable.
-        $mailer = new Mailer($userID);
-        $mailerStatus = $mailer->sendToOne(
-            array($destination, ''),
-            $subject,
-            $body,
-            true
-        );
+        try
+        {
+            $mailer = new Mailer($userID);
+            $mailer->sendToOne(
+                array($destination, ''),
+                $subject,
+                $body,
+                true
+            );
+        }
+        catch (\PHPMailer\PHPMailer\Exception $e)
+        {
+            // Mail not configured or unavailable - log and continue
+            error_log(
+                'OpenCATS CareerPortal mail error: '
+                . get_class($e) . ' [' . $e->getCode() . ']'
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

CareerPortal::sendEmail() throws an uncaught PHPMailer exception when 
no mail server is configured. This causes a fatal HTTP 500 error that 
prevents candidates from completing their application through the 
Career Portal — the application is saved to the database but the 
candidate sees an error page instead of a confirmation.

## Solution

Wrap the mail send call in try/catch to allow the application flow to 
continue normally when mail is unavailable.

The catch block:
- Catches \PHPMailer\PHPMailer\Exception specifically to avoid swallowing 
  unrelated application errors
- Logs the exception class and code via error_log() for debugging
- Avoids logging $e->getMessage() to prevent exposing sensitive SMTP 
  configuration details in logs

Note: $mailerStatus was removed as sendEmail() returns void and the 
return value of sendToOne() was never used by any caller.

## Testing

Tested on PHP 8.4.21 + MariaDB 10.11 + Debian 12 without a configured 
mail server. The candidate application flow completes successfully and 
the confirmation page is shown. The error is logged to the PHP error log.

## Context

This fix was suggested in the review of PR #792 by @anonymoususer72041:
> "The CareerPortal mailer try/catch is not covered here or in #797. 
> I agree it is a useful fix... a small targeted PR for that one would 
> probably be easiest to review."