### PR TITLE
fix: renumber duplicate install schema migration

### DIFF
--- a/modules/install/Schema.php
+++ b/modules/install/Schema.php
@@ -1538,7 +1538,7 @@ class CATSSchema
                 ALTER TABLE `contact` ADD COLUMN `country` VARCHAR(2) DEFAULT NULL AFTER `zip`;
                 ALTER TABLE `joborder` ADD COLUMN `country` VARCHAR(2) DEFAULT NULL AFTER `state`;
             ',
-            '382' => '
+            '383' => '
                 UPDATE
                     career_portal_template
                 SET
@@ -1591,7 +1591,7 @@ class CATSSchema
                     AND value LIKE \'%<label id="zipPostalLabel" for="zipPostal">*Zip/Postal Code:</label>%\'
                     AND value LIKE \'%<td><input-state></td>%\';
             ',
-            '383' => '
+            '384' => '
                 UPDATE
                     career_portal_template
                 SET
@@ -1657,11 +1657,11 @@ class CATSSchema
                         )
                     );
             ',
-            '384' => 'PHP:
-                include_once(\'modules/install/scripts/384.php\');
-                update_384($db);
+            '385' => 'PHP:
+                include_once(\'modules/install/scripts/385.php\');
+                update_385($db);
             ',
-            '385' => '
+            '386' => '
                 DROP TABLE IF EXISTS `candidate_jobordrer_status_type`;
                 DROP TABLE IF EXISTS `candidate_joborder_status_type`;
             ',

--- a/modules/install/scripts/385.php
+++ b/modules/install/scripts/385.php
@@ -1,10 +1,10 @@
 <?php
 /*
  * CATS
- * Update 384 - cleanup orphaned entity records and references
+ * Update 385 - cleanup orphaned entity records and references
  */
 
-function update_384($db)
+function update_385($db)
 {
     /* Collect orphaned attachment directories before deleting metadata rows. */
     $orphanAttachmentDirectories = array();


### PR DESCRIPTION
This PR fixes a duplicate install schema version in `modules/install/Schema.php`.

The current schema map contains two entries for version `382`. Because PHP array keys must be unique, the later entry overrides the earlier one, which prevents one of the intended install migrations from being reachable through the schema updater.

To restore a consistent migration sequence, this PR renumbers the affected cleanup migration from `384` to `385`, updates its install script filename, adjusts the update function name and updates the schema map accordingly.