### PR TITLE
chore: guard install schema migration keys

### DIFF
--- a/src/OpenCATS/Tests/UnitTests/SchemaMigrationsTest.php
+++ b/src/OpenCATS/Tests/UnitTests/SchemaMigrationsTest.php
@@ -1,0 +1,78 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/*
+ * Guards the install migration list in modules/install/Schema.php.
+ *
+ * The migrations are the string keys of the array returned by
+ * CATSSchema::get(). A duplicate key is NOT a PHP error: PHP silently keeps
+ * only the last occurrence, so the earlier migration is dropped before the
+ * upgrade runner (ModuleUtility::updateSchema) ever sees it. That surfaces
+ * later as a mysteriously missing table/column.
+ *
+ * Because PHP has already de-duplicated by the time the array is built, we
+ * cannot detect this from CATSSchema::get() -- we must scan the source text.
+ */
+class SchemaMigrationsTest extends TestCase
+{
+    /*
+     * Pre-existing duplicate keys that are intentionally left as-is for now.
+     * New duplicates must not be adde.
+     */
+    private const KNOWN_DUPLICATE_KEYS = array(283);
+
+    private function migrationKeysInSourceOrder(): array
+    {
+        $path = LEGACY_ROOT . '/modules/install/Schema.php';
+        $source = file_get_contents($path);
+        $this->assertNotFalse($source, "Could not read $path");
+
+        /*
+         * Array keys look like `    '123' => '` at the start of a line. The SQL
+         * values are single-quoted strings, so no such line-anchored pattern can
+         * appear inside them -- this reliably matches only the migration keys.
+         */
+        preg_match_all("/^\s*'(\d+)'\s*=>/m", $source, $matches);
+
+        return array_map('intval', $matches[1]);
+    }
+
+    public function testNoNewDuplicateMigrationKeys(): void
+    {
+        $keys = $this->migrationKeysInSourceOrder();
+        $this->assertNotEmpty($keys, 'No migration keys found in Schema.php');
+
+        $counts = array_count_values($keys);
+        $duplicates = array_keys(array_filter($counts, fn($n) => $n > 1));
+
+        $unexpected = array_diff($duplicates, self::KNOWN_DUPLICATE_KEYS);
+        sort($unexpected);
+
+        $this->assertSame(
+            array(),
+            $unexpected,
+            'Duplicate migration key(s) in Schema.php: ' . implode(', ', $unexpected)
+                . '. A duplicate key silently drops the earlier migration -- '
+                . 'use the next unused number instead.'
+        );
+    }
+
+    public function testMigrationKeysAreInAscendingOrder(): void
+    {
+        $keys = $this->migrationKeysInSourceOrder();
+
+        $previous = null;
+        foreach ($keys as $key)
+        {
+            if ($previous !== null)
+            {
+                $this->assertGreaterThanOrEqual(
+                    $previous,
+                    $key,
+                    "Migration key $key appears after $previous. Keys must be listed in ascending order."
+                );
+            }
+            $previous = $key;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds regression coverage for the install schema migration list in `modules/install/Schema.php`.

The install migrations are stored as PHP array keys. When the same migration key is added more than once, PHP silently keeps only the last entry, which means the earlier migration is no longer reachable by the upgrade runner. This can lead to missing schema changes that are hard to diagnose later.

The new unit test scans the `Schema.php` source directly so duplicate keys can be detected before PHP de-duplicates the array at runtime. It allows the currently known legacy duplicate key `283`, but fails for any newly introduced duplicate migration keys.

The test also verifies that migration keys remain listed in ascending order, making future install schema changes easier to review and reducing the risk of accidentally inserting migrations in the wrong place.