### PR TITLE
fix: align dependabot auto-merge trigger

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto-Merge
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This updates the Dependabot auto-merge workflow to follow GitHub’s documented Dependabot automation pattern more closely.

The workflow now runs on `pull_request` instead of `pull_request_target` and checks the pull request author via `github.event.pull_request.user.login`. This avoids using the elevated `pull_request_target` event where it is not needed, while keeping the workflow limited to Dependabot pull requests.

The workflow still uses `dependabot/fetch-metadata` and continues to enable squash auto-merge only for non-major dependency updates. Major updates remain excluded from automatic merging.