### PR TITLE
fix: only run install module migrations inside the install wizard

### DIFF
--- a/lib/ModuleUtility.php
+++ b/lib/ModuleUtility.php
@@ -441,6 +441,13 @@ class ModuleUtility
      */
     private static function processModuleSchema($moduleName, $schema)
     {
+        global $maintPage;
+        if ($moduleName === 'install' &&
+            (!isset($maintPage) || $maintPage !== true))
+        {
+            return;
+        }
+
         if( ini_get('safe_mode') )
         {
 			//don't do anything in safe mode
@@ -532,7 +539,6 @@ class ModuleUtility
             }
 
 			/* if maintPage, execute 1 query, output the next query and progress, and terminate. */
-			global $maintPage;
 			if ((isset($maintPage) && $maintPage === true))
 			{
 				if ($executedQuery == false)


### PR DESCRIPTION
The install module's schema migrations were processed on every bootstrap call, including regular page requests. This meant historical install migrations could be replayed unintentionally and uncontrolled during an ordinary request.

processModuleSchema() now returns early for the install module unless the install/migration wizard is active ($maintPage === true, set only in modules/install/ajax/maint.php). Install migrations therefore run exclusively through the wizard in a controlled manner. All other modules are unaffected, since the guard only applies when $moduleName === 'install'.