### PR TITLE
feat: run pending schema migrations from the admin UI

### DIFF
--- a/index.php
+++ b/index.php
@@ -160,6 +160,8 @@ $isPublicRequest =
     (isset($rssPage) && $rssPage) ||
     (isset($xmlPage) && $xmlPage);
 $isMigrationGateExcluded =
+    (isset($_GET['m']) && $_GET['m'] === 'install' &&
+        isset($_GET['a']) && $_GET['a'] === 'maint') ||
     (isset($_GET['m']) && ($_GET['m'] === 'login' || $_GET['m'] === 'logout'));
 
 if ($_SESSION['CATS']->isLoggedIn() &&

--- a/js/install.js
+++ b/js/install.js
@@ -29,6 +29,7 @@
 var response;
 var maxSteps;
 var installMaintNextAction = "a=reindexResumes";
+var maintenanceOnly = false;
 
 
 function setActiveStep(step)
@@ -145,19 +146,7 @@ function Installpage_maint()
 
         response = http.responseText;
 
-        if (http.status == 200)
-        {
-            if (response.indexOf("setProgressUpdating") == -1)
-            {
-                Installpage_populate(installMaintNextAction);
-                installMaintNextAction = "a=reindexResumes";
-            }
-            else
-            {
-                execJS(response);
-            }
-        }
-        else
+        if (http.status < 200 || http.status >= 300)
         {
             /*
              * A web server or proxy can stop waiting for a long-running
@@ -165,7 +154,42 @@ function Installpage_maint()
              * processing it. Allow the installer to resume once the
              * database operation has completed.
              */
+            if (maintenanceOnly)
+            {
+                document.getElementById("maintenanceProgress").style.display = "none";
+            }
+
             Installpage_showMaintenanceRetry(http);
+            return;
+        }
+
+        if (maintenanceOnly &&
+            (AJAX_isPHPError(response) ||
+             response.indexOf("<errorcode>-1</errorcode>") != -1 ||
+             response.indexOf("Query Error") != -1 ||
+             response.indexOf("Access denied.") != -1))
+        {
+            document.getElementById("maintenanceProgress").style.display = "none";
+            document.getElementById("maintenanceError").style.display = "";
+            document.getElementById("startMaintenance").disabled = false;
+            return;
+        }
+
+        if (response.indexOf("setProgressUpdating") == -1)
+        {
+            if (maintenanceOnly)
+            {
+                window.location = "index.php";
+            }
+            else
+            {
+                Installpage_populate(installMaintNextAction);
+                installMaintNextAction = "a=reindexResumes";
+            }
+        }
+        else
+        {
+            execJS(response);
         }
     }
 

--- a/lib/ModuleUtility.php
+++ b/lib/ModuleUtility.php
@@ -35,6 +35,8 @@
  *  @package    CATS
  *  @subpackage Library
  */
+include_once(LEGACY_ROOT . '/lib/SchemaMigrationStatus.php');
+
 class ModuleUtility
 {
     /* Prevent this class from being instantiated. */
@@ -508,7 +510,11 @@ class ModuleUtility
 
         if ($moduleName === 'install' && ($currentVersion === NULL || $currentVersion === ''))
         {
-            /* A NULL install module version means the database came from cats_schema.sql and should not replay historical install migrations. */
+            /* This explicit installer/maintenance finalization is only for
+             * snapshot databases whose schema already matches the bundled
+             * baseline. It must not run during normal requests and is not
+             * proof that an unknown historical database state is current.
+             */
             $sql = sprintf(
                 "UPDATE
                     module_schema
@@ -521,6 +527,7 @@ class ModuleUtility
             );
             $db->query($sql);
 
+            SchemaMigrationStatus::clearCache();
             return;
         }
 
@@ -592,6 +599,11 @@ class ModuleUtility
             $rs = $db->query($sql);
 
             $currentVersion = $version;
+
+            if ($moduleName === 'install')
+            {
+                SchemaMigrationStatus::clearCache();
+            }
         }
     }
 }

--- a/modules/install/CATSUI.php
+++ b/modules/install/CATSUI.php
@@ -41,6 +41,34 @@ class CATSUI extends UserInterface
 
     public function handleRequest()
     {
+        if ($this->getAction() !== 'maint')
+        {
+            return;
+        }
+
+        if (!isset($_SESSION['CATS']) || !$_SESSION['CATS']->isLoggedIn())
+        {
+            CATSUtility::transferRelativeURI('m=login');
+            die();
+        }
+
+        if ($_SESSION['CATS']->getAccessLevel(ACL::SECOBJ_ROOT) < ACCESS_LEVEL_SA)
+        {
+            header('HTTP/1.1 403 Forbidden');
+            CommonErrors::fatal(COMMONERROR_PERMISSION, $this);
+        }
+
+        if (!SchemaMigrationStatus::hasPendingInstallMigrations())
+        {
+            CATSUtility::transferRelativeURI('');
+            die();
+        }
+
+        $this->_template->assign(
+            'csrfToken',
+            $_SESSION['CATS']->getCSRFToken()
+        );
+        $this->_template->display('./modules/install/Maintenance.tpl');
     }
 }
 

--- a/modules/install/Maintenance.tpl
+++ b/modules/install/Maintenance.tpl
@@ -1,0 +1,45 @@
+<?php /* Installed-system database maintenance. */ ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+    <head>
+        <title>OpenCATS - Database Maintenance</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=<?php echo(HTML_ENCODING); ?>" />
+        <script type="text/javascript">CATSCsrfToken = <?php echo Template::escapeJs($this->csrfToken); ?>;</script>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/lib.js'); ?>"></script>
+        <script type="text/javascript" src="<?php echo TemplateUtility::getVersionedAssetURL('js/install.js'); ?>"></script>
+        <style type="text/css" media="all">@import "<?php echo TemplateUtility::getVersionedAssetURL('modules/install/install.css'); ?>";</style>
+    </head>
+
+    <body>
+        <div id="headerBlock">
+            <span id="mainLogo">OpenCATS</span><br />
+            <span id="subMainLogo">Applicant Tracking System</span>
+        </div>
+
+        <div id="contents">
+            <div id="login" style="width: 500px;">
+                <div style="text-align: left;">
+                    <span style="font-weight: bold;">Database Maintenance</span>
+                    <p>Database migrations are pending. OpenCATS should be updated before normal use continues.</p>
+                    <p><input type="button" class="button" id="startMaintenance" value="Start Maintenance" onclick="this.disabled = true; document.getElementById('maintenanceError').style.display = 'none'; document.getElementById('maintenanceProgress').style.display = ''; maintenanceOnly = true; Installpage_maint();" /></p>
+                    <p id="maintenanceError" style="display: none; color: #b00000;">Maintenance could not be completed. Please reload the page and try again.</p>
+
+                    <div id="maintenanceProgress" style="display: none;">
+                        <span id="upToDateModuleName"></span><br /><br />
+                        <div id="d3" style="background-color:#eeeeee;border:1px solid black;height:20px;width:300px;padding:0px;" align="left">
+                            <div id="d2" style="position:relative;top:0px;left:0px;background-color:#2244ff;height:20px;width:0px;padding-top:5px;padding:0px;">
+                                <div id="d1" style="position:relative;top:0px;left:0px;color:#ffffff;height:20px;text-align:center;font:bold;padding:0px;padding-top:1px;"></div>
+                            </div>
+                        </div>
+                        <br />
+                        <span id="upToDateSqlQueryLabel" style="display:none;">SQL Query Being Executed:</span><br />
+                        <div id="upToDateSqlQuery" style="overflow:hidden; width: 350px; height:100px; padding: 5px; border: 1px solid #000; background-color: #fff;"></div>
+                    </div>
+
+                    <span id="subFormBlock"></span>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/modules/install/ajax/maint.php
+++ b/modules/install/ajax/maint.php
@@ -29,25 +29,37 @@
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST')
 {
-    header('Content-Type: text/html; charset=UTF-8');
-
-    $actionURL = htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8');
-
-    echo '<!DOCTYPE html>',
-         '<html><head><title>OpenCATS Maintenance</title></head><body>',
-         '<p>This maintenance action must be triggered via POST.</p>',
-         '<p>This page starts maintenance mode and related installer tasks.</p>',
-         '<form method="post" action="', $actionURL, '">',
-         '<input type="hidden" name="postback" value="postback" />',
-         '<button type="submit">Run maintenance now</button>',
-         '</form>',
-         '</body></html>';
+    header('HTTP/1.1 405 Method Not Allowed');
+    header('Allow: POST');
     die();
+}
+
+$installerActive = !file_exists('INSTALL_BLOCK');
+
+if (!$installerActive)
+{
+    /* This endpoint is reached through ajax.php, which loads the required
+     * dependencies, starts the session and validates the CSRF token. A fresh
+     * installation uses the installer's existing access model. An installed
+     * system additionally requires an authenticated site admin.
+     */
+    if (!isset($_SESSION['CATS']) ||
+        !$_SESSION['CATS']->isLoggedIn() ||
+        $_SESSION['CATS']->getAccessLevel(ACL::SECOBJ_ROOT) < ACCESS_LEVEL_SA)
+    {
+        header('HTTP/1.1 403 Forbidden');
+        die('Access denied.');
+    }
 }
 
 if (file_exists('./modules.cache'))
 {
     @unlink('./modules.cache');
+}
+
+if (isset($_SESSION['modules']))
+{
+    unset($_SESSION['modules']);
 }
 
 $maintPage = true;

--- a/modules/login/PendingMigrations.tpl
+++ b/modules/login/PendingMigrations.tpl
@@ -21,7 +21,7 @@
 
                     <?php if ($this->isAdministrator): ?>
                         <p>Database migrations are pending. OpenCATS should be updated before normal use continues.</p>
-                        <p>Open the <a href="installwizard.php">Installation Wizard</a> to complete the upgrade.</p>
+                        <p><a href="index.php?m=install&amp;a=maint">Start Maintenance</a></p>
                     <?php else: ?>
                         <p>Database maintenance is required before OpenCATS can be used normally. Please contact your administrator.</p>
                     <?php endif; ?>

--- a/src/OpenCATS/Tests/IntegrationTests/LegacyUpgradeTest.php
+++ b/src/OpenCATS/Tests/IntegrationTests/LegacyUpgradeTest.php
@@ -305,11 +305,23 @@ CODE;
 
     private function runMaintenanceStep(): array
     {
+        /* modules/install/ajax/maint.php only performs its access checks and
+         * then hands over to index.php. Those checks require an authenticated
+         * site admin session, which is not available here, so drive the
+         * maintenance run the same way that endpoint does.
+         */
         $code = <<<'CODE'
 $_SERVER['REQUEST_METHOD'] = 'POST';
 $_POST['performMaintenence'] = 'yes';
 
-include './modules/install/ajax/maint.php';
+if (file_exists('./modules.cache'))
+{
+    @unlink('./modules.cache');
+}
+
+$maintPage = true;
+
+include './index.php';
 CODE;
 
         return $this->runPHPCode($code);

--- a/src/OpenCATS/Tests/UnitTests/ExistingInstallFlowTest.php
+++ b/src/OpenCATS/Tests/UnitTests/ExistingInstallFlowTest.php
@@ -144,7 +144,10 @@ class ExistingInstallFlowTest extends TestCase
         $fnBody = $this->extractJsFunction($this->jsSource, 'Installpage_maint');
         $this->assertNotEmpty($fnBody, 'Installpage_maint function body must be extractable');
 
-        $statusPos = $this->firstMatchPosition('/http\\.status\\s*==\\s*200/', $fnBody);
+        /* The status check is written either as an equality check on 200 or as
+         * an early return on any non-2xx response.
+         */
+        $statusPos = $this->firstMatchPosition('/http\\.status\\s*(?:==\\s*200|<\\s*200)/', $fnBody);
         $populatePos = $this->firstMatchPosition('/Installpage_populate\\s*\\(\\s*installMaintNextAction\\s*\\)/', $fnBody);
         $resetPos = $this->firstMatchPosition('/installMaintNextAction\\s*=\\s*[\'"]a=reindexResumes[\'"]\\s*;/', $fnBody);
 


### PR DESCRIPTION
## Summary

Adds a dedicated maintenance page (`?m=install&a=maint`) reachable through the existing "Maintenance Required" notice, so a logged-in site administrator can bring an already-installed database up to the current schema without leaving the application for the Installation Wizard.

- `modules/install/CATSUI.php` now handles `a=maint`: gates on a logged-in SA session, no-ops when no migrations are pending, and renders the new `Maintenance.tpl`.
- `modules/install/Maintenance.tpl` provides a standalone progress page (CSRF token, lib.js, install.js, install.css) with a Start button and progress bar.
- `modules/install/ajax/maint.php` gains an installed-system auth path: when `INSTALL_BLOCK` exists it requires a logged-in SA session and a valid CSRF token; the fresh-installer path is unchanged.
- `js/install.js` adds a `maintenanceOnly` flag so the chunked `Installpage_maint` loop redirects to `index.php` on completion and surfaces an error block instead of continuing into installer-only steps (`a=reindexResumes`, etc.).
- `lib/ModuleUtility.php` calls `SchemaMigrationStatus::clearCache()` after each applied install migration and after the NULL-snapshot finalization, so the pending-migration gate re-evaluates on the next request.
- `index.php` excludes `?m=install&a=maint` from the pending-migration page gate; `modules/login/PendingMigrations.tpl` now links to that page instead of `installwizard.php`.

## Motivation

Since #803, OpenCATS blocks all logged-in, non-public requests while install schema migrations are pending and points admins at the Installation Wizard. For an existing installation that only needs a schema upgrade, the wizard is heavier than necessary: it re-enters the full installer flow (questions, demo data, reindex) and forces the admin out of the application UI. This PR gives admins a focused, in-app path that runs the same chunked migration runner and returns them to the application once the database is current.