### PR TITLE
fix: resolve relative SystemUtility includes in installer AJAX endpoint

### DIFF
--- a/modules/install/ajax/ui.php
+++ b/modules/install/ajax/ui.php
@@ -293,6 +293,8 @@ switch ($action)
     case 'resumeParsing':
         echo '<script type="text/javascript">setActiveStep(4);</script>';
 
+        include_once(LEGACY_ROOT . '/lib/SystemUtility.php');
+
         if (ANTIWORD_PATH == '')
         {
             echo '
@@ -307,7 +309,6 @@ switch ($action)
         {
             $antiwordWithSlashes = str_replace('\\', '\\\\', ANTIWORD_PATH);
 
-            include_once ('lib/SystemUtility.php');
             /* Change Windows default command to UNIX default command hack. */
             if (strpos(strtolower($antiwordWithSlashes), "c:\\") === 0 && !SystemUtility::isWindows())
             {
@@ -337,7 +338,6 @@ switch ($action)
         {
             $pdftotextWithSlashes = str_replace('\\', '\\\\', PDFTOTEXT_PATH);
 
-            include_once ('lib/SystemUtility.php');
             /* Change Windows default command to UNIX default command hack. */
             if (strpos(strtolower($pdftotextWithSlashes), "c:\\") === 0 && !SystemUtility::isWindows())
             {
@@ -367,7 +367,6 @@ switch ($action)
         {
             $html2textWithSlashes = str_replace('\\', '\\\\', HTML2TEXT_PATH);
 
-            include_once ('lib/SystemUtility.php');
             /* Change Windows default command to UNIX default command hack. */
             if (strpos(strtolower($html2textWithSlashes), "c:\\") === 0 && !SystemUtility::isWindows())
             {
@@ -397,7 +396,6 @@ switch ($action)
         {
             $unrtfWithSlashes = str_replace('\\', '\\\\', UNRTF_PATH);
 
-            include_once ('lib/SystemUtility.php');
             /* Change Windows default command to UNIX default command hack. */
             if (strpos(strtolower($unrtfWithSlashes), "c:\\") === 0 && !SystemUtility::isWindows())
             {


### PR DESCRIPTION
## Problem

The `resumeParsing` case in `modules/install/ajax/ui.php` contained 
four repeated relative `include_once('lib/SystemUtility.php')` calls 
inside individual `else` blocks. Relative includes can fail when the 
endpoint is accessed directly from a different working directory.

## Solution

Replace the four repeated relative includes with a single 
`include_once(LEGACY_ROOT . '/lib/SystemUtility.php')` at the top of 
the `resumeParsing` case, before the conditional blocks.

This also removes the redundancy — `include_once` only loads the file 
once anyway, so four calls in separate branches were unnecessary.

## Context

This was noted as a pre-existing issue in PR #797:
> "modules/install/ajax/ui.php still contains some pre-existing 
> relative includes such as include_once('lib/SystemUtility.php') 
> in the resume parsing path. Those lines were already present before 
> this branch and were not introduced by this commit. Since they are 
> a separate legacy relative-path issue rather than part of the 
> bootstrap-order change, I would prefer to handle them in a follow-up PR."