### PR TITLE
fix: report the no-log success status from the queue CLI

### DIFF
--- a/QueueCLI.php
+++ b/QueueCLI.php
@@ -101,7 +101,7 @@ switch($retVal)
     case TASKRET_SUCCESS:
         echo "SUCCESS";
         break;
-    case TASKRET_SUCCESS:
+    case TASKRET_SUCCESS_NOLOG:
         echo "SUCCESS (NO LOG)";
         break;
 }


### PR DESCRIPTION
The status switch at the end of the script lists TASKRET_SUCCESS twice, and the second branch prints "SUCCESS (NO LOG)", which is the wording for TASKRET_SUCCESS_NOLOG. QueueProcessor::startTask returns whatever the task returned, so a task finishing without a log currently leaves the status line blank. I read this off constants.php and QueueProcessor, I have not run the queue processor itself.
